### PR TITLE
Feat/logica seguir aceite chat

### DIFF
--- a/src/components/perfil/CabecalhoPerfil.jsx
+++ b/src/components/perfil/CabecalhoPerfil.jsx
@@ -110,15 +110,10 @@ export default function CabecalhoPerfil({
             <span className="material-symbols-outlined">person_remove</span>
             <span className="btn-texto">Deixar de seguir</span>
           </button>
-          {chatLiberado ? (
+          {chatLiberado && (
             <button className="btn-cabecalho btn-mensagem" onClick={onMensagem}>
               <span className="material-symbols-outlined">chat</span>
               <span className="btn-texto">Mensagem</span>
-            </button>
-          ) : (
-            <button className="btn-cabecalho btn-pendente" disabled>
-              <span className="material-symbols-outlined">schedule</span>
-              <span className="btn-texto">Aguardando chat</span>
             </button>
           )}
         </>

--- a/src/components/perfil/CabecalhoPerfil.jsx
+++ b/src/components/perfil/CabecalhoPerfil.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import './Cabecalhoperfil.css';
 import './Profilemenu.css';
@@ -14,15 +14,17 @@ export default function CabecalhoPerfil({
   localizacao,
   isOwnProfile,
   isFollowing,
+  statusSolicitacao,
+  chatLiberado,
   onSeguir,
   onDeixarDeSeguir,
+  onCancelarSolicitacao,  
   onMensagem,
 }) {
   const navigate = useNavigate();
   const fileInputFotoRef = useRef(null);
   const fileInputBannerRef = useRef(null);
 
-  // Estado do menu e dark mode
   const [menuAberto, setMenuAberto] = useState(false);
   const [isDarkMode, setIsDarkMode] = useState(() => {
     return localStorage.getItem('theme') === 'dark';
@@ -65,9 +67,74 @@ export default function CabecalhoPerfil({
     if (typeof onBannerChange === 'function') onBannerChange(file);
   };
 
+  const renderizarBotoes = () => {
+    if (isOwnProfile) {
+      return (
+        <>
+          <button className="btn-cabecalho btn-editar" onClick={() => navigate('/perfil/editar')}>
+            <span className="material-symbols-outlined">edit</span>
+            <span className="btn-texto">Editar Perfil</span>
+          </button>
+          <button className="btn-cabecalho btn-publicar" onClick={() => navigate('/publicar')}>
+            <span className="material-symbols-outlined">add</span>
+            <span className="btn-texto">Nova Publicação</span>
+          </button>
+        </>
+      );
+    }
+
+    // Ainda verificando status — não renderiza nada para evitar flash
+    if (statusSolicitacao === null) {
+      return (
+        <button className="btn-cabecalho btn-pendente" disabled style={{ opacity: 0, pointerEvents: 'none' }}>
+          <span className="material-symbols-outlined">hourglass_empty</span>
+          <span className="btn-texto">Carregando</span>
+        </button>
+      );
+    }
+
+    // Solicitação pendente — clicável para cancelar, ícone de relógio para UX clara
+    if (statusSolicitacao === 'pendente') {
+      return (
+        <button className="btn-cabecalho btn-cancelar" onClick={onCancelarSolicitacao}>
+          <span className="material-symbols-outlined">hourglass_empty</span>
+          <span className="btn-texto">Solicitação enviada</span>
+        </button>
+      );
+    }
+
+    if (isFollowing) {
+      return (
+        <>
+          <button className="btn-cabecalho btn-deixar-seguir" onClick={onDeixarDeSeguir}>
+            <span className="material-symbols-outlined">person_remove</span>
+            <span className="btn-texto">Deixar de seguir</span>
+          </button>
+          {chatLiberado ? (
+            <button className="btn-cabecalho btn-mensagem" onClick={onMensagem}>
+              <span className="material-symbols-outlined">chat</span>
+              <span className="btn-texto">Mensagem</span>
+            </button>
+          ) : (
+            <button className="btn-cabecalho btn-pendente" disabled>
+              <span className="material-symbols-outlined">schedule</span>
+              <span className="btn-texto">Aguardando chat</span>
+            </button>
+          )}
+        </>
+      );
+    }
+
+    return (
+      <button className="btn-cabecalho btn-seguir" onClick={onSeguir}>
+        <span className="material-symbols-outlined">person_add</span>
+        <span className="btn-texto">Seguir</span>
+      </button>
+    );
+  };
+
   return (
     <div className="cabecalho-perfil">
-
       {/* BANNER */}
       <div
         className="banner-perfil"
@@ -78,15 +145,12 @@ export default function CabecalhoPerfil({
         {!banner && isOwnProfile && (
           <span className="banner-icone material-symbols-outlined">add_photo_alternate</span>
         )}
-
         {isOwnProfile && (
           <div className="banner-overlay">
             <span className="material-symbols-outlined">photo_camera</span>
             <p>Trocar capa</p>
           </div>
         )}
-
-        {/* Botão 3 pontos — só aparece no próprio perfil, no mobile */}
         {isOwnProfile && (
           <button
             className="pmenu-trigger"
@@ -98,10 +162,8 @@ export default function CabecalhoPerfil({
         )}
       </div>
 
-      {/* LINHA INFERIOR: foto + botões desktop */}
+      {/* LINHA INFERIOR */}
       <div className="cabecalho-inferior">
-
-        {/* FOTO */}
         <div className="foto-perfil-wrapper">
           <img
             src={fotoPerfil || null}
@@ -117,107 +179,44 @@ export default function CabecalhoPerfil({
           )}
         </div>
 
-        {/* BOTÕES DESKTOP */}
+        {/* Botões desktop */}
         <div className="cabecalho-botoes">
-          {isOwnProfile ? (
-            <>
-              <button className="btn-cabecalho btn-editar" onClick={() => navigate('/perfil/editar')}>
-                <span className="material-symbols-outlined">edit</span>
-                <span className="btn-texto">Editar Perfil</span>
-              </button>
-              <button className="btn-cabecalho btn-publicar" onClick={() => navigate('/publicar')}>
-                <span className="material-symbols-outlined">add</span>
-                <span className="btn-texto">Nova Publicação</span>
-              </button>
-            </>
-          ) : (
-            <>
-{!isFollowing ? (
-  <button className="btn-cabecalho btn-seguir" onClick={onSeguir}>
-    <span className="material-symbols-outlined">person_add</span>
-    <span className="btn-texto">Seguir</span>
-  </button>
-) : (
-  <>
-    <button className="btn-cabecalho btn-deixar-seguir" onClick={onDeixarDeSeguir}>
-      <span className="material-symbols-outlined">person_remove</span>
-      <span className="btn-texto">Deixar de seguir</span>
-    </button>
-    <button className="btn-cabecalho btn-mensagem" onClick={onMensagem}>
-      <span className="material-symbols-outlined">chat</span>
-      <span className="btn-texto">Mensagem</span>
-    </button>
-  </>
-)}
-            </>
-          )}
+          {renderizarBotoes()}
         </div>
       </div>
 
-      {/* INPUTS ocultos */}
+      {/* Inputs ocultos */}
       {isOwnProfile && (
         <>
           <input type="file" accept="image/*" ref={fileInputBannerRef} style={{ display: 'none' }} onChange={handleBannerChange} />
-          <input type="file" accept="image/*" ref={fileInputFotoRef}   style={{ display: 'none' }} onChange={handleFotoChange}   />
+          <input type="file" accept="image/*" ref={fileInputFotoRef} style={{ display: 'none' }} onChange={handleFotoChange} />
         </>
       )}
 
-      {/* INFO DO USUÁRIO */}
+      {/* INFO USUÁRIO */}
       <div className="usuario-data">
         <h2 className="usuario-nome">{usuario?.nome || 'Usuário'}</h2>
-
         {usuario?.email && (
           <div className="usuario-info-linha">
             <span className="material-symbols-outlined usuario-icone">mail</span>
             <span className="usuario-info-texto">{usuario.email}</span>
           </div>
         )}
-
         {localizacao && (
           <div className="usuario-info-linha">
             <span className="material-symbols-outlined usuario-icone">location_on</span>
             <span className="usuario-info-texto">{localizacao}</span>
           </div>
         )}
-
         {bio && <p className="usuario-bio">{bio}</p>}
       </div>
 
-      {/* BOTÕES MOBILE (Editar / Publicar / Seguir) */}
-<div className="cabecalho-botoes-mobile">
-  {isOwnProfile ? (
-    <>
-      <button className="btn-cabecalho btn-editar" onClick={() => navigate('/perfil/editar')}>
-        Editar Perfil
-      </button>
-      <button className="btn-cabecalho btn-publicar" onClick={() => navigate('/publicar')}>
-        Nova Publicação
-      </button>
-    </>
-  ) : (
-    <>
-      {!isFollowing ? (
-        <button className="btn-cabecalho btn-seguir" onClick={onSeguir}>
-          <span className="material-symbols-outlined">person_add</span>
-          <span>Seguir</span>
-        </button>
-      ) : (
-        <>
-          <button className="btn-cabecalho btn-deixar-seguir" onClick={onDeixarDeSeguir}>
-            <span className="material-symbols-outlined">person_remove</span>
-            <span>Deixar de seguir</span>
-          </button>
-          <button className="btn-cabecalho btn-mensagem" onClick={onMensagem}>
-            <span className="material-symbols-outlined">chat</span>
-            <span>Mensagem</span>
-          </button>
-        </>
-      )}
-    </>
-  )}
-</div>
+      {/* Botões mobile */}
+      <div className="cabecalho-botoes-mobile">
+        {renderizarBotoes()}
+      </div>
 
-      {/* BOTTOM SHEET MENU */}
+      {/* Menu */}
       <ProfileMenu
         isOpen={menuAberto}
         onClose={() => setMenuAberto(false)}

--- a/src/components/perfil/CabecalhoPerfil.jsx
+++ b/src/components/perfil/CabecalhoPerfil.jsx
@@ -14,11 +14,9 @@ export default function CabecalhoPerfil({
   localizacao,
   isOwnProfile,
   isFollowing,
-  statusSolicitacao,
   chatLiberado,
   onSeguir,
   onDeixarDeSeguir,
-  onCancelarSolicitacao,  
   onMensagem,
 }) {
   const navigate = useNavigate();
@@ -68,6 +66,7 @@ export default function CabecalhoPerfil({
   };
 
   const renderizarBotoes = () => {
+    // ── Perfil próprio ──
     if (isOwnProfile) {
       return (
         <>
@@ -83,32 +82,13 @@ export default function CabecalhoPerfil({
       );
     }
 
-    // Ainda verificando status — não renderiza nada para evitar flash
-    if (statusSolicitacao === null) {
-      return (
-        <button className="btn-cabecalho btn-pendente" disabled style={{ opacity: 0, pointerEvents: 'none' }}>
-          <span className="material-symbols-outlined">hourglass_empty</span>
-          <span className="btn-texto">Carregando</span>
-        </button>
-      );
-    }
-
-    // Solicitação pendente — clicável para cancelar, ícone de relógio para UX clara
-    if (statusSolicitacao === 'pendente') {
-      return (
-        <button className="btn-cabecalho btn-cancelar" onClick={onCancelarSolicitacao}>
-          <span className="material-symbols-outlined">hourglass_empty</span>
-          <span className="btn-texto">Solicitação enviada</span>
-        </button>
-      );
-    }
-
+    // ── Já segue B ──
     if (isFollowing) {
       return (
         <>
           <button className="btn-cabecalho btn-deixar-seguir" onClick={onDeixarDeSeguir}>
             <span className="material-symbols-outlined">person_remove</span>
-            <span className="btn-texto">Deixar de seguir</span>
+            <span className="btn-texto">Seguindo</span>
           </button>
           {chatLiberado && (
             <button className="btn-cabecalho btn-mensagem" onClick={onMensagem}>
@@ -120,6 +100,7 @@ export default function CabecalhoPerfil({
       );
     }
 
+    // ── Não segue B ──
     return (
       <button className="btn-cabecalho btn-seguir" onClick={onSeguir}>
         <span className="material-symbols-outlined">person_add</span>

--- a/src/components/perfil/Cabecalhoperfil.css
+++ b/src/components/perfil/Cabecalhoperfil.css
@@ -394,3 +394,195 @@ body.dark-mode .btn-cancelar:hover {
   background-color: rgba(248, 113, 113, 0.15);
   color: #fca5a5;
 }
+
+/* ==============================================
+   BOTÃO SEGUIR DE VOLTA — MODAL DE SEGUIDORES
+   ============================================== */
+
+/* Item do modal */
+.modal-usuario-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  cursor: pointer;
+  transition: background 0.15s;
+  border-radius: 8px;
+}
+
+.modal-usuario-item:hover {
+  background: #f8fafc;
+}
+
+.modal-usuario-foto {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.modal-usuario-foto-placeholder {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: #e2e8f0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: #94a3b8;
+}
+
+.modal-usuario-nome {
+  flex: 1;
+  font-size: 14px;
+  font-weight: 500;
+  color: #1e293b;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Botão seguir/seguindo dentro do modal */
+.modal-btn-seguir {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 14px;
+  border-radius: 20px;
+  border: 1.5px solid #062A6C;
+  background: #062A6C;
+  color: #ffffff;
+  font-size: 12px;
+  font-weight: 600;
+  font-family: 'Open Sans', Arial, sans-serif;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: background 0.15s, color 0.15s, border-color 0.15s, transform 0.12s;
+}
+
+.modal-btn-seguir .material-symbols-outlined {
+  font-size: 14px;
+}
+
+.modal-btn-seguir:hover {
+  background: #0a3a8f;
+  border-color: #0a3a8f;
+  transform: scale(1.03);
+}
+
+.modal-btn-seguir:active {
+  transform: scale(0.97);
+}
+
+/* Estado "já seguindo" — contorno, fundo branco */
+.modal-btn-seguindo {
+  background: #ffffff;
+  color: #062A6C;
+  border-color: #062A6C;
+}
+
+.modal-btn-seguindo:hover {
+  background: #fef2f2;
+  color: #e53e3e;
+  border-color: #e53e3e;
+}
+
+/* Loading spinner no botão */
+.modal-btn-loading {
+  font-size: 14px;
+  animation: spin-notif 0.8s linear infinite;
+}
+
+@keyframes spin-notif {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+/* ==============================================
+   BOTÃO "SEGUINDO" ATIVO — CARD DE NOTIFICAÇÃO
+   ============================================== */
+.notif-btn-seguindo-ativo {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 20px;
+  border: 1.5px solid #062A6C;
+  background: #ffffff;
+  color: #062A6C;
+  font-size: 11.5px;
+  font-family: 'Open Sans', Arial, sans-serif;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s, transform 0.12s;
+  white-space: nowrap;
+}
+
+.notif-btn-seguindo-ativo .material-symbols-outlined {
+  font-size: 13px;
+}
+
+.notif-btn-seguindo-ativo:hover {
+  background: #fef2f2;
+  color: #e53e3e;
+  border-color: #e53e3e;
+}
+
+.notif-btn-seguindo-ativo:active {
+  transform: scale(0.96);
+}
+
+/* ==============================================
+   DARK MODE
+   ============================================== */
+body.dark-mode .modal-usuario-item:hover {
+  background: #1e293b;
+}
+
+body.dark-mode .modal-usuario-nome {
+  color: #e2e8f0;
+}
+
+body.dark-mode .modal-usuario-foto-placeholder {
+  background: #334155;
+  color: #64748b;
+}
+
+body.dark-mode .modal-btn-seguir {
+  background: #1a3a7c;
+  border-color: #93b4f0;
+  color: #ffffff;
+}
+
+body.dark-mode .modal-btn-seguir:hover {
+  background: #2451a8;
+  border-color: #93b4f0;
+}
+
+body.dark-mode .modal-btn-seguindo {
+  background: transparent;
+  color: #93b4f0;
+  border-color: #93b4f0;
+}
+
+body.dark-mode .modal-btn-seguindo:hover {
+  background: rgba(248, 113, 113, 0.12);
+  color: #f87171;
+  border-color: #f87171;
+}
+
+body.dark-mode .notif-btn-seguindo-ativo {
+  background: transparent;
+  color: #93b4f0;
+  border-color: #93b4f0;
+}
+
+body.dark-mode .notif-btn-seguindo-ativo:hover {
+  background: rgba(248, 113, 113, 0.12);
+  color: #f87171;
+  border-color: #f87171;
+}

--- a/src/components/perfil/Cabecalhoperfil.css
+++ b/src/components/perfil/Cabecalhoperfil.css
@@ -346,3 +346,51 @@ body.dark-mode .btn-mensagem:hover {
   border-color: #1b5e20;
   box-shadow: 0 4px 12px rgba(46, 125, 50, 0.35);
 }
+
+/* Botão pendente – desabilitado */
+.btn-pendente {
+  background-color: #f3f4f6;
+  color: #6b7280;
+  border: 2px solid #d1d5db;
+  cursor: not-allowed;
+  opacity: 0.8;
+}
+
+.btn-pendente:hover {
+  background-color: #f3f4f6;
+  transform: none;
+  box-shadow: none;
+}
+
+/* Caso queira um tom mais escuro no dark mode */
+body.dark-mode .btn-pendente {
+  background-color: #374151;
+  color: #9ca3af;
+  border-color: #4b5563;
+}
+
+/* Botão cancelar solicitação */
+.btn-cancelar {
+  background-color: #fff;
+  color: #e53e3e;           /* vermelho suave */
+  border: 2px solid #e53e3e;
+}
+
+.btn-cancelar:hover {
+  background-color: #e53e3e;
+  color: #fff;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(229, 62, 62, 0.35);
+}
+
+/* Dark mode */
+body.dark-mode .btn-cancelar {
+  background-color: transparent;
+  color: #f87171;
+  border-color: #f87171;
+}
+
+body.dark-mode .btn-cancelar:hover {
+  background-color: rgba(248, 113, 113, 0.15);
+  color: #fca5a5;
+}

--- a/src/components/perfil/EstatisticasPerfil.jsx
+++ b/src/components/perfil/EstatisticasPerfil.jsx
@@ -1,13 +1,32 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { db } from "../../firebase";
-import { doc, getDoc } from "firebase/firestore";
+import {
+  doc,
+  getDoc,
+  updateDoc,
+  arrayUnion,
+  arrayRemove,
+  addDoc,
+  collection,
+  serverTimestamp,
+  query,
+  where,
+  getDocs,
+  deleteDoc,
+} from "firebase/firestore";
 
-function ModalUsuarios({ titulo, ids, onFechar }) {
+// ── Modal de lista de usuários (seguidores / seguindo) ──
+function ModalUsuarios({ titulo, ids, currentUserId, isOwnProfile, onFechar }) {
   const navigate = useNavigate();
   const [usuarios, setUsuarios] = useState([]);
   const [carregando, setCarregando] = useState(true);
+  // Mapa de uid → true se currentUser já segue aquele usuario
+  const [seguindoMap, setSeguindoMap] = useState({});
+  const [loadingMap, setLoadingMap] = useState({});
 
+  // Busca usuários e, se for o próprio perfil olhando seus seguidores,
+  // busca quem o currentUser já segue para mostrar o botão correto
   useEffect(() => {
     if (!ids || ids.length === 0) {
       setCarregando(false);
@@ -21,27 +40,102 @@ function ModalUsuarios({ titulo, ids, onFechar }) {
         )
       );
       const results = await Promise.all(promises);
-      setUsuarios(results.filter(Boolean));
+      const validos = results.filter(Boolean);
+      setUsuarios(validos);
+
+      // Descobre quem currentUser já segue (para o botão seguir de volta)
+      if (currentUserId) {
+        const meSnap = await getDoc(doc(db, "usuarios", currentUserId));
+        const meusSeguindo = meSnap.exists() ? meSnap.data().seguindo || [] : [];
+        const mapa = {};
+        validos.forEach((u) => {
+          mapa[u.id] = meusSeguindo.includes(u.id);
+        });
+        setSeguindoMap(mapa);
+      }
+
       setCarregando(false);
     };
 
     buscar();
-  }, [ids]);
+  }, [ids, currentUserId]);
 
   const irParaPerfil = (id) => {
     onFechar();
     navigate(`/perfil/${id}`);
   };
 
+  // ── Seguir de volta direto (sem solicitação) ──
+  const seguirDeVolta = async (e, usuarioAlvo) => {
+    e.stopPropagation();
+    if (!currentUserId || loadingMap[usuarioAlvo.id]) return;
+
+    setLoadingMap((prev) => ({ ...prev, [usuarioAlvo.id]: true }));
+
+    try {
+      // Adiciona alvo nos "seguindo" do currentUser
+      await updateDoc(doc(db, "usuarios", currentUserId), {
+        seguindo: arrayUnion(usuarioAlvo.id),
+      });
+      // Adiciona currentUser nos "seguidores" do alvo
+      await updateDoc(doc(db, "usuarios", usuarioAlvo.id), {
+        seguidores: arrayUnion(currentUserId),
+      });
+      // Busca nome do currentUser para notificação
+      const meSnap = await getDoc(doc(db, "usuarios", currentUserId));
+      const meuNome = meSnap.exists() ? meSnap.data().nome || "Pescador" : "Pescador";
+      // Notifica o alvo que foi seguido de volta
+      await addDoc(collection(db, "notificacoes"), {
+        tipo: "seguindo",
+        de: meuNome,
+        de_id: currentUserId,
+        para: usuarioAlvo.id,
+        lida: false,
+        createdAt: serverTimestamp(),
+      });
+      setSeguindoMap((prev) => ({ ...prev, [usuarioAlvo.id]: true }));
+    } catch (err) {
+      console.error("Erro ao seguir de volta:", err);
+    } finally {
+      setLoadingMap((prev) => ({ ...prev, [usuarioAlvo.id]: false }));
+    }
+  };
+
+  // ── Deixar de seguir (dentro do modal) ──
+  const deixarDeSeguir = async (e, usuarioAlvo) => {
+    e.stopPropagation();
+    if (!currentUserId || loadingMap[usuarioAlvo.id]) return;
+
+    setLoadingMap((prev) => ({ ...prev, [usuarioAlvo.id]: true }));
+
+    try {
+      await updateDoc(doc(db, "usuarios", currentUserId), {
+        seguindo: arrayRemove(usuarioAlvo.id),
+      });
+      await updateDoc(doc(db, "usuarios", usuarioAlvo.id), {
+        seguidores: arrayRemove(currentUserId),
+      });
+      // Remove notificação de seguindo que enviamos anteriormente
+      const q = query(
+        collection(db, "notificacoes"),
+        where("tipo", "==", "seguindo"),
+        where("de_id", "==", currentUserId),
+        where("para", "==", usuarioAlvo.id)
+      );
+      const snap = await getDocs(q);
+      await Promise.all(snap.docs.map((d) => deleteDoc(d.ref)));
+
+      setSeguindoMap((prev) => ({ ...prev, [usuarioAlvo.id]: false }));
+    } catch (err) {
+      console.error("Erro ao deixar de seguir:", err);
+    } finally {
+      setLoadingMap((prev) => ({ ...prev, [usuarioAlvo.id]: false }));
+    }
+  };
+
   return (
-    <div
-      className="modal-seguidores-fundo"
-      onClick={onFechar}
-    >
-      <div
-        className="modal-seguidores"
-        onClick={(e) => e.stopPropagation()}
-      >
+    <div className="modal-seguidores-fundo" onClick={onFechar}>
+      <div className="modal-seguidores" onClick={(e) => e.stopPropagation()}>
         <div className="modal-seguidores-header">
           <h3 className="modal-seguidores-titulo">{titulo}</h3>
           <button className="modal-seguidores-fechar" onClick={onFechar}>
@@ -61,26 +155,63 @@ function ModalUsuarios({ titulo, ids, onFechar }) {
               <p>Nenhum usuário encontrado.</p>
             </div>
           ) : (
-            usuarios.map((u) => (
-              <div
-                key={u.id}
-                className="modal-usuario-item"
-                onClick={() => irParaPerfil(u.id)}
-              >
-                {u.fotoPerfil ? (
-                  <img
-                    src={u.fotoPerfil}
-                    alt={u.nome}
-                    className="modal-usuario-foto"
-                  />
-                ) : (
-                  <div className="modal-usuario-foto-placeholder">
-                    <span className="material-symbols-outlined">person</span>
-                  </div>
-                )}
-                <span className="modal-usuario-nome">{u.nome || "Usuário"}</span>
-              </div>
-            ))
+            usuarios.map((u) => {
+              const jaSeguindo = seguindoMap[u.id];
+              const carregandoBtn = loadingMap[u.id];
+              // Não mostra botão no próprio perfil do currentUser
+              const ehOMesmo = u.id === currentUserId;
+
+              return (
+                <div
+                  key={u.id}
+                  className="modal-usuario-item"
+                  onClick={() => irParaPerfil(u.id)}
+                >
+                  {u.fotoPerfil ? (
+                    <img
+                      src={u.fotoPerfil}
+                      alt={u.nome}
+                      className="modal-usuario-foto"
+                    />
+                  ) : (
+                    <div className="modal-usuario-foto-placeholder">
+                      <span className="material-symbols-outlined">person</span>
+                    </div>
+                  )}
+
+                  <span className="modal-usuario-nome">{u.nome || "Usuário"}</span>
+
+                  {/* Botão seguir/seguindo — só para usuários que não são o próprio */}
+                  {!ehOMesmo && (
+                    <button
+                      className={`modal-btn-seguir ${jaSeguindo ? "modal-btn-seguindo" : ""}`}
+                      onClick={(e) =>
+                        jaSeguindo
+                          ? deixarDeSeguir(e, u)
+                          : seguirDeVolta(e, u)
+                      }
+                      disabled={carregandoBtn}
+                    >
+                      {carregandoBtn ? (
+                        <span className="material-symbols-outlined modal-btn-loading">
+                          hourglass_empty
+                        </span>
+                      ) : jaSeguindo ? (
+                        <>
+                          <span className="material-symbols-outlined">person_check</span>
+                          Seguindo
+                        </>
+                      ) : (
+                        <>
+                          <span className="material-symbols-outlined">person_add</span>
+                          Seguir
+                        </>
+                      )}
+                    </button>
+                  )}
+                </div>
+              );
+            })
           )}
         </div>
       </div>
@@ -88,7 +219,7 @@ function ModalUsuarios({ titulo, ids, onFechar }) {
   );
 }
 
-export default function EstatisticasPerfil({ totalPosts, usuario }) {
+export default function EstatisticasPerfil({ totalPosts, usuario, currentUserId, isOwnProfile }) {
   const [modalAberto, setModalAberto] = useState(null); // 'seguidores' | 'seguindo' | null
 
   const seguidores = usuario?.seguidores || [];
@@ -125,6 +256,8 @@ export default function EstatisticasPerfil({ totalPosts, usuario }) {
         <ModalUsuarios
           titulo="Seguidores"
           ids={seguidores}
+          currentUserId={currentUserId}
+          isOwnProfile={isOwnProfile}
           onFechar={() => setModalAberto(null)}
         />
       )}
@@ -133,6 +266,8 @@ export default function EstatisticasPerfil({ totalPosts, usuario }) {
         <ModalUsuarios
           titulo="Seguindo"
           ids={seguindo}
+          currentUserId={currentUserId}
+          isOwnProfile={isOwnProfile}
           onFechar={() => setModalAberto(null)}
         />
       )}

--- a/src/pages/Notificacao/notificacao.jsx
+++ b/src/pages/Notificacao/notificacao.jsx
@@ -8,16 +8,19 @@ import {
   query,
   where,
   onSnapshot,
-  orderBy,
   deleteDoc,
   doc,
   updateDoc,
   writeBatch,
+  arrayUnion,
+  arrayRemove,
+  setDoc,
+  serverTimestamp,
+  addDoc,
 } from "firebase/firestore";
 
 import { observeAuthState } from "../../auth";
 
-// ── Tempo até arquivar após lida (5 minutos em ms) ──
 const TEMPO_ARQUIVAR_MS = 5 * 60 * 1000;
 
 const TIPOS = [
@@ -30,24 +33,19 @@ const TIPOS = [
 ];
 
 export default function Notificacao() {
-  const [user, setUser]               = useState(null);
+  const [user, setUser] = useState(null);
   const [notificacoes, setNotificacoes] = useState([]);
-  // Arquivadas: só memória local, some ao deslogar
-  const [arquivadas, setArquivadas]   = useState([]);
-  const [filtro, setFiltro]           = useState("todas");
+  const [arquivadas, setArquivadas] = useState([]);
+  const [filtro, setFiltro] = useState("todas");
 
-  // Mapa de timers: { [id]: timeoutId }
-  // Usamos useRef para não recriar o mapa a cada render
   const timersRef = useRef({});
 
-  // 🔐 Auth — limpa arquivadas ao deslogar
+  // Auth
   useEffect(() => {
     const unsubscribe = observeAuthState((u) => {
       setUser(u);
       if (!u) {
-        // usuário deslogou: limpa arquivadas da memória
         setArquivadas([]);
-        // cancela todos os timers pendentes
         Object.values(timersRef.current).forEach(clearTimeout);
         timersRef.current = {};
       }
@@ -55,47 +53,45 @@ export default function Notificacao() {
     return unsubscribe;
   }, []);
 
-  // 🔔 Notificações em tempo real
+  // Firestore realtime
   useEffect(() => {
     if (!user) return;
-
+    // Sem orderBy — evita exigir índice composto no Firestore.
+    // A ordenação é feita localmente abaixo, após receber os dados.
     const q = query(
       collection(db, "notificacoes"),
-      where("para", "==", user.uid),
-      orderBy("createdAt", "desc")
+      where("para", "==", user.uid)
     );
-
-    const unsubscribe = onSnapshot(q, (snapshot) => {
+    const unsub = onSnapshot(q, (snapshot) => {
       setNotificacoes((prev) => {
         const localMap = Object.fromEntries(prev.map((n) => [n.id, n]));
-        return snapshot.docs.map((d) => {
+        const docs = snapshot.docs.map((d) => {
           const remoto = { id: d.id, ...d.data() };
-          const local  = localMap[d.id];
-          // mantém atualização otimista de lida
+          const local = localMap[d.id];
           if (local?.lida && !remoto.lida) return { ...remoto, lida: true };
           return remoto;
         });
+        // Ordenação local por createdAt desc — evita índice composto no Firestore
+        return docs.sort((a, b) => {
+          const ta = a.createdAt?.seconds ?? 0;
+          const tb = b.createdAt?.seconds ?? 0;
+          return tb - ta;
+        });
       });
     });
-
-    return unsubscribe;
+    return unsub;
   }, [user]);
 
-  // ⏳ Motor de arquivamento — observa notificações lidas e agenda timer
+  // Arquivamento automático
   useEffect(() => {
     notificacoes.forEach((n) => {
-      // só agenda se: está lida, não tem timer rodando e não está arquivada
       if (
         n.lida &&
         !timersRef.current[n.id] &&
         !arquivadas.find((a) => a.id === n.id)
       ) {
-        timersRef.current[n.id] = setTimeout(() => {
-          arquivar(n);
-        }, TEMPO_ARQUIVAR_MS);
+        timersRef.current[n.id] = setTimeout(() => arquivar(n), TEMPO_ARQUIVAR_MS);
       }
-
-      // se ficou não-lida de novo (ex: edge case), cancela o timer
       if (!n.lida && timersRef.current[n.id]) {
         clearTimeout(timersRef.current[n.id]);
         delete timersRef.current[n.id];
@@ -103,26 +99,20 @@ export default function Notificacao() {
     });
   }, [notificacoes]);
 
-  // 📦 Arquivar: move para memória local e apaga do Firestore
   const arquivar = async (notif) => {
-    // adiciona nas arquivadas locais
     setArquivadas((prev) => {
       if (prev.find((a) => a.id === notif.id)) return prev;
       return [notif, ...prev];
     });
-    // remove da lista ativa
     setNotificacoes((prev) => prev.filter((n) => n.id !== notif.id));
-    // limpa o timer
     delete timersRef.current[notif.id];
-    // apaga do Firestore
     try {
       await deleteDoc(doc(db, "notificacoes", notif.id));
     } catch (e) {
-      console.error("[arquivar] erro ao deletar:", e);
+      console.error("[arquivar] erro:", e);
     }
   };
 
-  // 🗑️ Excluir da lista ativa
   const excluirNotificacao = async (id) => {
     clearTimeout(timersRef.current[id]);
     delete timersRef.current[id];
@@ -130,12 +120,10 @@ export default function Notificacao() {
     await deleteDoc(doc(db, "notificacoes", id));
   };
 
-  // 🗑️ Excluir das arquivadas (só local, já saiu do Firestore)
   const excluirArquivada = (id) => {
     setArquivadas((prev) => prev.filter((a) => a.id !== id));
   };
 
-  // ✅ Marcar uma como lida — otimista
   const marcarComoLida = async (id, lida) => {
     if (lida) return;
     setNotificacoes((prev) =>
@@ -144,48 +132,119 @@ export default function Notificacao() {
     await updateDoc(doc(db, "notificacoes", id), { lida: true });
   };
 
-  // ✅ Marcar todas como lidas — otimista
   const marcarTodasComoLidas = async () => {
     if (!user) return;
     const naoLidas = notificacoes.filter((n) => !n.lida);
     if (naoLidas.length === 0) return;
-
     setNotificacoes((prev) => prev.map((n) => ({ ...n, lida: true })));
-
     const batch = writeBatch(db);
-    naoLidas.forEach((n) => {
-      batch.update(doc(db, "notificacoes", n.id), { lida: true });
-    });
+    naoLidas.forEach((n) => batch.update(doc(db, "notificacoes", n.id), { lida: true }));
     await batch.commit();
   };
 
-  // ⏱️ Tempo relativo
-  const tempoRelativo = (timestamp) => {
-    if (!timestamp) return "";
-    const agora = new Date();
-    const data  = new Date(timestamp.seconds * 1000);
-    const diff  = Math.floor((agora - data) / 1000);
-
-    if (diff < 60)      return "agora";
-    if (diff < 3600)    return `há ${Math.floor(diff / 60)} min`;
-    if (diff < 86400)   return `há ${Math.floor(diff / 3600)} h`;
-    if (diff < 2592000) return `há ${Math.floor(diff / 86400)} dias`;
-    return data.toLocaleDateString();
+  // ── AÇÕES DA SOLICITAÇÃO ──
+  const aceitarSeguidor = async (notif) => {
+    if (!notif) return;
+    try {
+      // Adiciona A nos seguidores de B
+      await updateDoc(doc(db, "usuarios", notif.para), {
+        seguidores: arrayUnion(notif.de_id),
+      });
+      // Notifica A de que foi aceito como seguidor
+      await addDoc(collection(db, "notificacoes"), {
+        tipo: "solicitacao_aceita_seguidor",
+        de: user?.displayName || "Usuário",
+        de_id: notif.para,     // id de B (quem aceitou)
+        para: notif.de_id,     // notificar A
+        lida: false,
+        createdAt: serverTimestamp(),
+      });
+      await deleteDoc(doc(db, "notificacoes", notif.id));
+      setNotificacoes((prev) => prev.filter((n) => n.id !== notif.id));
+    } catch (e) {
+      console.error("Erro ao aceitar seguidor:", e);
+    }
   };
 
-  // 📅 É hoje?
+  const aceitarChat = async (notif) => {
+    if (!notif) return;
+    try {
+      await updateDoc(doc(db, "usuarios", notif.para), {
+        seguidores: arrayUnion(notif.de_id),
+      });
+      const chatId = [notif.de_id, notif.para].sort().join("_");
+      await setDoc(doc(db, "chat_permissions", chatId), {
+        accepted: true,
+        createdAt: new Date(),
+      });
+      // Notifica A de que foi aceito no chat
+      await addDoc(collection(db, "notificacoes"), {
+        tipo: "solicitacao_aceita_chat",
+        de: user?.displayName || "Usuário",
+        de_id: notif.para,
+        para: notif.de_id,
+        lida: false,
+        createdAt: serverTimestamp(),
+      });
+      await deleteDoc(doc(db, "notificacoes", notif.id));
+      setNotificacoes((prev) => prev.filter((n) => n.id !== notif.id));
+    } catch (e) {
+      console.error("Erro ao aceitar chat:", e);
+    }
+  };
+
+const recusarSolicitacao = async (notif) => {
+  if (!notif) return;
+  try {
+    // Remove B do array "seguindo" de A
+    await updateDoc(doc(db, "usuarios", notif.de_id), {
+      seguindo: arrayRemove(notif.para),
+    });
+    // Gera notificação para A (recusado)
+    await addDoc(collection(db, "notificacoes"), {
+      tipo: "solicitacao_recusada",
+      de: user?.displayName || "Usuário",
+      de_id: notif.para,
+      para: notif.de_id,
+      lida: false,
+      createdAt: serverTimestamp(),
+    });
+    // Remove a solicitação original
+    await deleteDoc(doc(db, "notificacoes", notif.id));
+    
+    // Atualiza estado local imediatamente (opcional, mas ajuda)
+    setNotificacoes(prev => prev.filter(n => n.id !== notif.id));
+    
+    console.log('Recusa processada, listener deve atualizar statusSolicitacao no perfil');
+  } catch (e) {
+    console.error("Erro ao recusar:", e);
+  }
+};
+
+  // ── FUNÇÕES AUXILIARES ──
   const isHoje = (timestamp) => {
     if (!timestamp) return false;
-    const data  = new Date(timestamp.seconds * 1000);
+    const data = new Date(timestamp.seconds * 1000);
     const agora = new Date();
     return (
-      data.getDate()     === agora.getDate() &&
-      data.getMonth()    === agora.getMonth() &&
+      data.getDate() === agora.getDate() &&
+      data.getMonth() === agora.getMonth() &&
       data.getFullYear() === agora.getFullYear()
     );
   };
 
-  // 💬 Texto da notificação
+  const tempoRelativo = (timestamp) => {
+    if (!timestamp) return "";
+    const agora = new Date();
+    const data = new Date(timestamp.seconds * 1000);
+    const diff = Math.floor((agora - data) / 1000);
+    if (diff < 60) return "agora";
+    if (diff < 3600) return `há ${Math.floor(diff / 60)} min`;
+    if (diff < 86400) return `há ${Math.floor(diff / 3600)} h`;
+    if (diff < 2592000) return `há ${Math.floor(diff / 86400)} dias`;
+    return data.toLocaleDateString();
+  };
+
   const renderTexto = (n) => {
     switch (n.tipo) {
       case "seguindo":
@@ -206,58 +265,74 @@ export default function Notificacao() {
             {n.texto && <span className="notif-quote">"{n.texto}"</span>}
           </>
         );
+      case "solicitacao_seguir":
+        return <><strong>{n.de}</strong> quer te seguir</>;
+      case "solicitacao_aceita_seguidor":
+        return <><strong>{n.de}</strong> aceitou sua solicitação de seguidor</>;
+      case "solicitacao_aceita_chat":
+        return <><strong>{n.de}</strong> aceitou você como seguidor e liberou o chat</>;
+      case "solicitacao_recusada":
+        return <><strong>{n.de}</strong> recusou sua solicitação de seguir</>;
       default:
         return "Nova notificação";
     }
   };
 
-  // 🎨 Classe do avatar
   const avatarClass = (tipo) => {
     const map = {
-      seguindo:    "seguidor",
-      curtida:     "curtida",
-      comentario:  "comentario",
-      mensagem:    "mensagem",
+      seguindo: "seguidor",
+      curtida: "curtida",
+      comentario: "comentario",
+      mensagem: "mensagem",
+      solicitacao_seguir: "seguidor",
+      solicitacao_aceita_seguidor: "seguidor",
+      solicitacao_aceita_chat: "seguidor",
+      solicitacao_recusada: "seguidor",
     };
     return map[tipo] || "seguidor";
   };
 
-  // 🔤 Iniciais
   const iniciais = (nome = "") =>
     nome.split(" ").slice(0, 2).map((p) => p[0]?.toUpperCase()).join("");
 
-  // 🔢 Contagem não lidas por tipo
   const contarNaoLidas = (tipo) => {
     const base = notificacoes.filter((n) => !n.lida);
     if (tipo === "todas") return base.length;
     if (tipo === "arquivadas") return 0;
+    // Incluir todos os tipos de seguidores
+    if (tipo === "seguindo") {
+      return base.filter((n) =>
+        ["seguindo", "solicitacao_seguir", "solicitacao_aceita_seguidor", "solicitacao_aceita_chat", "solicitacao_recusada"].includes(n.tipo)
+      ).length;
+    }
     return base.filter((n) => n.tipo === tipo).length;
   };
 
-  // 📋 Lista ativa filtrada (exclui aba arquivadas das filtradas normais)
+  // ── FILTRO ──
+  const filtrarNotificacoes = () => {
+    if (filtro === "arquivadas") return [];
+    if (filtro === "todas") return notificacoes;
+    if (filtro === "seguindo") {
+      return notificacoes.filter((n) =>
+        ["seguindo", "solicitacao_seguir", "solicitacao_aceita_seguidor", "solicitacao_aceita_chat", "solicitacao_recusada"].includes(n.tipo)
+      );
+    }
+    return notificacoes.filter((n) => n.tipo === filtro);
+  };
+
+  const notifFiltradas = filtrarNotificacoes();
+  const hoje = notifFiltradas.filter((n) => isHoje(n.createdAt));
+  const anteriores = notifFiltradas.filter((n) => !isHoje(n.createdAt));
   const estaEmArquivadas = filtro === "arquivadas";
 
-  const notifFiltradas = estaEmArquivadas
-    ? []
-    : filtro === "todas"
-      ? notificacoes
-      : notificacoes.filter((n) => n.tipo === filtro);
-
-  const hoje       = notifFiltradas.filter((n) =>  isHoje(n.createdAt));
-  const anteriores = notifFiltradas.filter((n) => !isHoje(n.createdAt));
-
-  // Limpeza de timers ao desmontar o componente
   useEffect(() => {
-    return () => {
-      Object.values(timersRef.current).forEach(clearTimeout);
-    };
+    return () => Object.values(timersRef.current).forEach(clearTimeout);
   }, []);
 
   return (
     <Layout>
       <div className="notif-wrapper">
-
-        {/* ── ABAS ── */}
+        {/* Abas */}
         <div className="notif-header">
           <div className="notif-tabs">
             {TIPOS.map((t) => {
@@ -273,11 +348,9 @@ export default function Notificacao() {
                     {t.icon}
                   </span>
                   {t.label}
-                  {/* badge de quantidade para arquivadas */}
                   {isArq && arquivadas.length > 0 && (
                     <span className="tab-badge tab-badge--arquivo">{arquivadas.length}</span>
                   )}
-                  {/* badge de não lidas para as outras abas */}
                   {!isArq && count > 0 && (
                     <span className="tab-badge">{count}</span>
                   )}
@@ -287,10 +360,8 @@ export default function Notificacao() {
           </div>
         </div>
 
-        {/* ── LISTA ── */}
+        {/* Lista */}
         <div className="container-notificacoes">
-
-          {/* ── MODO NORMAL ── */}
           {!estaEmArquivadas && (
             <>
               {hoje.length > 0 && (
@@ -309,12 +380,14 @@ export default function Notificacao() {
                         onExcluir={excluirNotificacao}
                         timersRef={timersRef}
                         tempoArquivarMs={TEMPO_ARQUIVAR_MS}
+                        onAceitarSeguidor={aceitarSeguidor}
+                        onAceitarChat={aceitarChat}
+                        onRecusar={recusarSolicitacao}
                       />
                     ))}
                   </div>
                 </>
               )}
-
               {anteriores.length > 0 && (
                 <>
                   <span className="section-label" style={{ marginTop: 8 }}>Anteriores</span>
@@ -331,12 +404,14 @@ export default function Notificacao() {
                         onExcluir={excluirNotificacao}
                         timersRef={timersRef}
                         tempoArquivarMs={TEMPO_ARQUIVAR_MS}
+                        onAceitarSeguidor={aceitarSeguidor}
+                        onAceitarChat={aceitarChat}
+                        onRecusar={recusarSolicitacao}
                       />
                     ))}
                   </div>
                 </>
               )}
-
               {notifFiltradas.length === 0 && (
                 <div className="vazio">
                   <span className="material-symbols-outlined">notifications_off</span>
@@ -345,16 +420,12 @@ export default function Notificacao() {
               )}
             </>
           )}
-
-          {/* ── MODO ARQUIVADAS ── */}
           {estaEmArquivadas && (
             <>
-              {/* aviso de sessão */}
               <div className="arquivo-aviso">
                 <span className="material-symbols-outlined">info</span>
                 As notificações arquivadas somem quando você sair da conta.
               </div>
-
               {arquivadas.length > 0 ? (
                 <div className="notif-section">
                   {arquivadas.map((n) => (
@@ -365,7 +436,7 @@ export default function Notificacao() {
                       iniciais={iniciais}
                       renderTexto={renderTexto}
                       tempoRelativo={tempoRelativo}
-                      onLida={() => {}} // já lida, sem ação
+                      onLida={() => {}}
                       onExcluir={excluirArquivada}
                       isArquivada
                     />
@@ -381,8 +452,6 @@ export default function Notificacao() {
           )}
         </div>
       </div>
-
-      {/* ── FAB — só aparece fora da aba arquivadas ── */}
       {!estaEmArquivadas && (
         <button className="fab-marcar" onClick={marcarTodasComoLidas}>
           <span className="material-symbols-outlined">done_all</span>
@@ -393,9 +462,7 @@ export default function Notificacao() {
   );
 }
 
-/* ──────────────────────────────────────────────
-   CARD — mostra countdown quando lida e aguardando arquivamento
-────────────────────────────────────────────── */
+// Componente CardNotificacao
 function CardNotificacao({
   n,
   avatarClass,
@@ -407,24 +474,19 @@ function CardNotificacao({
   timersRef,
   tempoArquivarMs,
   isArquivada = false,
+  onAceitarSeguidor,
+  onAceitarChat,
+  onRecusar,
 }) {
   const tipoClass = avatarClass(n.tipo);
-
-  // countdown visual: segundos restantes até arquivar
   const [segundosRestantes, setSegundosRestantes] = useState(null);
+  const isSolicitacao = n.tipo === "solicitacao_seguir";
 
   useEffect(() => {
     if (!n.lida || isArquivada || !timersRef) return;
-
-    // verifica se tem timer rodando pra esse card
     if (!timersRef.current[n.id]) return;
-
-    // calcula quando o timer vai disparar
-    // como não temos o timestamp exato do início, estimamos pela
-    // presença do timer — recalculamos a cada segundo
     const totalSeg = Math.floor(tempoArquivarMs / 1000);
     setSegundosRestantes(totalSeg);
-
     const interval = setInterval(() => {
       setSegundosRestantes((prev) => {
         if (prev === null || prev <= 1) {
@@ -434,7 +496,6 @@ function CardNotificacao({
         return prev - 1;
       });
     }, 1000);
-
     return () => clearInterval(interval);
   }, [n.lida, n.id]);
 
@@ -450,24 +511,17 @@ function CardNotificacao({
       className={`notif-card ${n.lida ? "lida" : "nao-lida"} ${isArquivada ? "arquivada" : ""}`}
       onClick={() => onLida(n.id, n.lida)}
     >
-      {/* Avatar */}
       <div className={`notif-avatar ${tipoClass}`}>
         {iniciais(n.de)}
         <span className={`tipo-icon ${tipoClass}`}>
-          <span className="material-symbols-outlined">
-            {tipoIcone(n.tipo)}
-          </span>
+          <span className="material-symbols-outlined">{tipoIcone(n.tipo)}</span>
         </span>
       </div>
-
-      {/* Conteúdo */}
       <div className="notif-content">
         <p className="notif-text">{renderTexto(n)}</p>
         <div className="notif-meta">
           {!n.lida && <span className="dot-unread" />}
           <span className="notif-time">{tempoRelativo(n.createdAt)}</span>
-
-          {/* countdown de arquivamento */}
           {n.lida && !isArquivada && segundosRestantes !== null && (
             <span className="notif-arquivando">
               <span className="material-symbols-outlined" style={{ fontSize: 11 }}>
@@ -477,9 +531,32 @@ function CardNotificacao({
             </span>
           )}
         </div>
+        {isSolicitacao && !isArquivada && (
+          <div className="notif-toast__acoes" style={{ marginTop: 8 }}>
+            <button
+              className="notif-toast__btn notif-toast__btn--seguindo"
+              onClick={(e) => { e.stopPropagation(); onAceitarSeguidor(n); }}
+            >
+              <span className="material-symbols-outlined">person_add</span>
+              Aceitar seguidor
+            </button>
+            <button
+              className="notif-toast__btn notif-toast__btn--mensagem"
+              onClick={(e) => { e.stopPropagation(); onAceitarChat(n); }}
+            >
+              <span className="material-symbols-outlined">chat</span>
+              Aceitar no chat
+            </button>
+            <button
+              className="notif-toast__btn notif-toast__btn--curtida"
+              onClick={(e) => { e.stopPropagation(); onRecusar(n); }}
+            >
+              <span className="material-symbols-outlined">close</span>
+              Recusar
+            </button>
+          </div>
+        )}
       </div>
-
-      {/* Excluir */}
       <div className="notif-actions">
         <button
           className="btn-excluir"
@@ -495,10 +572,14 @@ function CardNotificacao({
 
 function tipoIcone(tipo) {
   switch (tipo) {
-    case "seguindo":    return "person_add";
-    case "curtida":     return "favorite";
-    case "comentario":  return "chat_bubble";
-    case "mensagem":    return "send";
-    default:            return "notifications";
+    case "seguindo": return "person_add";
+    case "curtida": return "favorite";
+    case "comentario": return "chat_bubble";
+    case "mensagem": return "send";
+    case "solicitacao_seguir": return "person_add";
+    case "solicitacao_aceita_seguidor": return "person_add";
+    case "solicitacao_aceita_chat": return "chat";
+    case "solicitacao_recusada": return "person_remove";
+    default: return "notifications";
   }
 }

--- a/src/pages/Notificacao/notificacao.jsx
+++ b/src/pages/Notificacao/notificacao.jsx
@@ -14,7 +14,6 @@ import {
   writeBatch,
   arrayUnion,
   arrayRemove,
-  setDoc,
   serverTimestamp,
   addDoc,
 } from "firebase/firestore";
@@ -143,6 +142,7 @@ export default function Notificacao() {
   };
 
   // ── AÇÕES DA SOLICITAÇÃO ──
+  // Aceitar = adiciona A nos seguidores de B + chat liberado automaticamente
   const aceitarSeguidor = async (notif) => {
     if (!notif) return;
     try {
@@ -150,36 +150,9 @@ export default function Notificacao() {
       await updateDoc(doc(db, "usuarios", notif.para), {
         seguidores: arrayUnion(notif.de_id),
       });
-      // Notifica A de que foi aceito como seguidor
+      // Notifica A — aceito como seguidor, chat liberado automaticamente
       await addDoc(collection(db, "notificacoes"), {
         tipo: "solicitacao_aceita_seguidor",
-        de: user?.displayName || "Usuário",
-        de_id: notif.para,     // id de B (quem aceitou)
-        para: notif.de_id,     // notificar A
-        lida: false,
-        createdAt: serverTimestamp(),
-      });
-      await deleteDoc(doc(db, "notificacoes", notif.id));
-      setNotificacoes((prev) => prev.filter((n) => n.id !== notif.id));
-    } catch (e) {
-      console.error("Erro ao aceitar seguidor:", e);
-    }
-  };
-
-  const aceitarChat = async (notif) => {
-    if (!notif) return;
-    try {
-      await updateDoc(doc(db, "usuarios", notif.para), {
-        seguidores: arrayUnion(notif.de_id),
-      });
-      const chatId = [notif.de_id, notif.para].sort().join("_");
-      await setDoc(doc(db, "chat_permissions", chatId), {
-        accepted: true,
-        createdAt: new Date(),
-      });
-      // Notifica A de que foi aceito no chat
-      await addDoc(collection(db, "notificacoes"), {
-        tipo: "solicitacao_aceita_chat",
         de: user?.displayName || "Usuário",
         de_id: notif.para,
         para: notif.de_id,
@@ -189,37 +162,32 @@ export default function Notificacao() {
       await deleteDoc(doc(db, "notificacoes", notif.id));
       setNotificacoes((prev) => prev.filter((n) => n.id !== notif.id));
     } catch (e) {
-      console.error("Erro ao aceitar chat:", e);
+      console.error("Erro ao aceitar:", e);
     }
   };
 
-const recusarSolicitacao = async (notif) => {
-  if (!notif) return;
-  try {
-    // Remove B do array "seguindo" de A
-    await updateDoc(doc(db, "usuarios", notif.de_id), {
-      seguindo: arrayRemove(notif.para),
-    });
-    // Gera notificação para A (recusado)
-    await addDoc(collection(db, "notificacoes"), {
-      tipo: "solicitacao_recusada",
-      de: user?.displayName || "Usuário",
-      de_id: notif.para,
-      para: notif.de_id,
-      lida: false,
-      createdAt: serverTimestamp(),
-    });
-    // Remove a solicitação original
-    await deleteDoc(doc(db, "notificacoes", notif.id));
-    
-    // Atualiza estado local imediatamente (opcional, mas ajuda)
-    setNotificacoes(prev => prev.filter(n => n.id !== notif.id));
-    
-    console.log('Recusa processada, listener deve atualizar statusSolicitacao no perfil');
-  } catch (e) {
-    console.error("Erro ao recusar:", e);
-  }
-};
+  const recusarSolicitacao = async (notif) => {
+    if (!notif) return;
+    try {
+      // Remove B do array "seguindo" de A — A não segue mais B
+      await updateDoc(doc(db, "usuarios", notif.de_id), {
+        seguindo: arrayRemove(notif.para),
+      });
+      // Notifica A de que foi recusado
+      await addDoc(collection(db, "notificacoes"), {
+        tipo: "solicitacao_recusada",
+        de: user?.displayName || "Usuário",
+        de_id: notif.para,   // B (quem recusou)
+        para: notif.de_id,   // A (quem pediu)
+        lida: false,
+        createdAt: serverTimestamp(),
+      });
+      await deleteDoc(doc(db, "notificacoes", notif.id));
+      setNotificacoes((prev) => prev.filter((n) => n.id !== notif.id));
+    } catch (e) {
+      console.error("Erro ao recusar:", e);
+    }
+  };
 
   // ── FUNÇÕES AUXILIARES ──
   const isHoje = (timestamp) => {
@@ -268,9 +236,7 @@ const recusarSolicitacao = async (notif) => {
       case "solicitacao_seguir":
         return <><strong>{n.de}</strong> quer te seguir</>;
       case "solicitacao_aceita_seguidor":
-        return <><strong>{n.de}</strong> aceitou sua solicitação de seguidor</>;
-      case "solicitacao_aceita_chat":
-        return <><strong>{n.de}</strong> aceitou você como seguidor e liberou o chat</>;
+        return <><strong>{n.de}</strong> aceitou sua solicitação — agora vocês podem conversar no chat</>;
       case "solicitacao_recusada":
         return <><strong>{n.de}</strong> recusou sua solicitação de seguir</>;
       default:
@@ -381,7 +347,6 @@ const recusarSolicitacao = async (notif) => {
                         timersRef={timersRef}
                         tempoArquivarMs={TEMPO_ARQUIVAR_MS}
                         onAceitarSeguidor={aceitarSeguidor}
-                        onAceitarChat={aceitarChat}
                         onRecusar={recusarSolicitacao}
                       />
                     ))}
@@ -405,7 +370,6 @@ const recusarSolicitacao = async (notif) => {
                         timersRef={timersRef}
                         tempoArquivarMs={TEMPO_ARQUIVAR_MS}
                         onAceitarSeguidor={aceitarSeguidor}
-                        onAceitarChat={aceitarChat}
                         onRecusar={recusarSolicitacao}
                       />
                     ))}
@@ -475,7 +439,6 @@ function CardNotificacao({
   tempoArquivarMs,
   isArquivada = false,
   onAceitarSeguidor,
-  onAceitarChat,
   onRecusar,
 }) {
   const tipoClass = avatarClass(n.tipo);
@@ -538,14 +501,7 @@ function CardNotificacao({
               onClick={(e) => { e.stopPropagation(); onAceitarSeguidor(n); }}
             >
               <span className="material-symbols-outlined">person_add</span>
-              Aceitar seguidor
-            </button>
-            <button
-              className="notif-toast__btn notif-toast__btn--mensagem"
-              onClick={(e) => { e.stopPropagation(); onAceitarChat(n); }}
-            >
-              <span className="material-symbols-outlined">chat</span>
-              Aceitar no chat
+              Aceitar
             </button>
             <button
               className="notif-toast__btn notif-toast__btn--curtida"

--- a/src/pages/Notificacao/notificacao.jsx
+++ b/src/pages/Notificacao/notificacao.jsx
@@ -16,6 +16,8 @@ import {
   arrayRemove,
   serverTimestamp,
   addDoc,
+  getDoc,
+  getDocs,
 } from "firebase/firestore";
 
 import { observeAuthState } from "../../auth";
@@ -23,12 +25,12 @@ import { observeAuthState } from "../../auth";
 const TEMPO_ARQUIVAR_MS = 5 * 60 * 1000;
 
 const TIPOS = [
-  { key: "todas",      label: "Todas",        icon: "notifications" },
-  { key: "seguindo",   label: "Seguidores",   icon: "person_add" },
-  { key: "curtida",    label: "Curtidas",     icon: "favorite" },
-  { key: "comentario", label: "Comentários",  icon: "chat_bubble" },
-  { key: "mensagem",   label: "Mensagens",    icon: "send" },
-  { key: "arquivadas", label: "Arquivadas",   icon: "archive" },
+  { key: "todas",      label: "Todas",       icon: "notifications" },
+  { key: "seguindo",   label: "Seguidores",  icon: "person_add"    },
+  { key: "curtida",    label: "Curtidas",    icon: "favorite"      },
+  { key: "comentario", label: "Comentários", icon: "chat_bubble"   },
+  { key: "mensagem",   label: "Mensagens",   icon: "send"          },
+  { key: "arquivadas", label: "Arquivadas",  icon: "archive"       },
 ];
 
 export default function Notificacao() {
@@ -36,6 +38,8 @@ export default function Notificacao() {
   const [notificacoes, setNotificacoes] = useState([]);
   const [arquivadas, setArquivadas] = useState([]);
   const [filtro, setFiltro] = useState("todas");
+  // Mapa uid → bool: currentUser já segue aquela pessoa?
+  const [seguindoMap, setSeguindoMap] = useState({});
 
   const timersRef = useRef({});
 
@@ -45,6 +49,7 @@ export default function Notificacao() {
       setUser(u);
       if (!u) {
         setArquivadas([]);
+        setSeguindoMap({});
         Object.values(timersRef.current).forEach(clearTimeout);
         timersRef.current = {};
       }
@@ -55,13 +60,11 @@ export default function Notificacao() {
   // Firestore realtime
   useEffect(() => {
     if (!user) return;
-    // Sem orderBy — evita exigir índice composto no Firestore.
-    // A ordenação é feita localmente abaixo, após receber os dados.
     const q = query(
       collection(db, "notificacoes"),
       where("para", "==", user.uid)
     );
-    const unsub = onSnapshot(q, (snapshot) => {
+    const unsub = onSnapshot(q, async (snapshot) => {
       setNotificacoes((prev) => {
         const localMap = Object.fromEntries(prev.map((n) => [n.id, n]));
         const docs = snapshot.docs.map((d) => {
@@ -70,13 +73,29 @@ export default function Notificacao() {
           if (local?.lida && !remoto.lida) return { ...remoto, lida: true };
           return remoto;
         });
-        // Ordenação local por createdAt desc — evita índice composto no Firestore
         return docs.sort((a, b) => {
           const ta = a.createdAt?.seconds ?? 0;
           const tb = b.createdAt?.seconds ?? 0;
           return tb - ta;
         });
       });
+
+      // Atualiza mapa de "seguindo" para os remetentes das notifs do tipo "seguindo"
+      const deIds = snapshot.docs
+        .map((d) => d.data())
+        .filter((d) => d.tipo === "seguindo")
+        .map((d) => d.de_id)
+        .filter(Boolean);
+
+      if (deIds.length > 0 && user?.uid) {
+        const meSnap = await getDoc(doc(db, "usuarios", user.uid));
+        const meusSeguindo = meSnap.exists() ? meSnap.data().seguindo || [] : [];
+        const mapa = {};
+        deIds.forEach((uid) => {
+          mapa[uid] = meusSeguindo.includes(uid);
+        });
+        setSeguindoMap((prev) => ({ ...prev, ...mapa }));
+      }
     });
     return unsub;
   }, [user]);
@@ -84,11 +103,7 @@ export default function Notificacao() {
   // Arquivamento automático
   useEffect(() => {
     notificacoes.forEach((n) => {
-      if (
-        n.lida &&
-        !timersRef.current[n.id] &&
-        !arquivadas.find((a) => a.id === n.id)
-      ) {
+      if (n.lida && !timersRef.current[n.id] && !arquivadas.find((a) => a.id === n.id)) {
         timersRef.current[n.id] = setTimeout(() => arquivar(n), TEMPO_ARQUIVAR_MS);
       }
       if (!n.lida && timersRef.current[n.id]) {
@@ -141,55 +156,67 @@ export default function Notificacao() {
     await batch.commit();
   };
 
-  // ── AÇÕES DA SOLICITAÇÃO ──
-  // Aceitar = adiciona A nos seguidores de B + chat liberado automaticamente
-  const aceitarSeguidor = async (notif) => {
-    if (!notif) return;
+  // ── SEGUIR DE VOLTA (a partir da notificação) ──
+  const seguirDeVolta = async (notif) => {
+    if (!user || !notif.de_id) return;
+    const alvoId = notif.de_id;
+
     try {
-      // Adiciona A nos seguidores de B
-      await updateDoc(doc(db, "usuarios", notif.para), {
-        seguidores: arrayUnion(notif.de_id),
+      // currentUser segue o remetente
+      await updateDoc(doc(db, "usuarios", user.uid), {
+        seguindo: arrayUnion(alvoId),
       });
-      // Notifica A — aceito como seguidor, chat liberado automaticamente
+      // remetente ganha currentUser como seguidor
+      await updateDoc(doc(db, "usuarios", alvoId), {
+        seguidores: arrayUnion(user.uid),
+      });
+      // Busca nome do currentUser
+      const meSnap = await getDoc(doc(db, "usuarios", user.uid));
+      const meuNome = meSnap.exists() ? meSnap.data().nome || "Pescador" : "Pescador";
+      // Notifica o remetente que foi seguido de volta
       await addDoc(collection(db, "notificacoes"), {
-        tipo: "solicitacao_aceita_seguidor",
-        de: user?.displayName || "Usuário",
-        de_id: notif.para,
-        para: notif.de_id,
+        tipo: "seguindo",
+        de: meuNome,
+        de_id: user.uid,
+        para: alvoId,
         lida: false,
         createdAt: serverTimestamp(),
       });
-      await deleteDoc(doc(db, "notificacoes", notif.id));
-      setNotificacoes((prev) => prev.filter((n) => n.id !== notif.id));
-    } catch (e) {
-      console.error("Erro ao aceitar:", e);
+      setSeguindoMap((prev) => ({ ...prev, [alvoId]: true }));
+    } catch (err) {
+      console.error("Erro ao seguir de volta:", err);
     }
   };
 
-  const recusarSolicitacao = async (notif) => {
-    if (!notif) return;
+  // ── DEIXAR DE SEGUIR (a partir da notificação) ──
+  const deixarDeSeguirNotif = async (notif) => {
+    if (!user || !notif.de_id) return;
+    const alvoId = notif.de_id;
+
     try {
-      // Remove B do array "seguindo" de A — A não segue mais B
-      await updateDoc(doc(db, "usuarios", notif.de_id), {
-        seguindo: arrayRemove(notif.para),
+      await updateDoc(doc(db, "usuarios", user.uid), {
+        seguindo: arrayRemove(alvoId),
       });
-      // Notifica A de que foi recusado
-      await addDoc(collection(db, "notificacoes"), {
-        tipo: "solicitacao_recusada",
-        de: user?.displayName || "Usuário",
-        de_id: notif.para,   // B (quem recusou)
-        para: notif.de_id,   // A (quem pediu)
-        lida: false,
-        createdAt: serverTimestamp(),
+      await updateDoc(doc(db, "usuarios", alvoId), {
+        seguidores: arrayRemove(user.uid),
       });
-      await deleteDoc(doc(db, "notificacoes", notif.id));
-      setNotificacoes((prev) => prev.filter((n) => n.id !== notif.id));
-    } catch (e) {
-      console.error("Erro ao recusar:", e);
+      // Remove notificação de seguindo que enviamos ao alvo
+      const q = query(
+        collection(db, "notificacoes"),
+        where("tipo", "==", "seguindo"),
+        where("de_id", "==", user.uid),
+        where("para", "==", alvoId)
+      );
+      const snap = await getDocs(q);
+      await Promise.all(snap.docs.map((d) => deleteDoc(d.ref)));
+
+      setSeguindoMap((prev) => ({ ...prev, [alvoId]: false }));
+    } catch (err) {
+      console.error("Erro ao deixar de seguir:", err);
     }
   };
 
-  // ── FUNÇÕES AUXILIARES ──
+  // ── AUXILIARES ──
   const isHoje = (timestamp) => {
     if (!timestamp) return false;
     const data = new Date(timestamp.seconds * 1000);
@@ -233,12 +260,6 @@ export default function Notificacao() {
             {n.texto && <span className="notif-quote">"{n.texto}"</span>}
           </>
         );
-      case "solicitacao_seguir":
-        return <><strong>{n.de}</strong> quer te seguir</>;
-      case "solicitacao_aceita_seguidor":
-        return <><strong>{n.de}</strong> aceitou sua solicitação — agora vocês podem conversar no chat</>;
-      case "solicitacao_recusada":
-        return <><strong>{n.de}</strong> recusou sua solicitação de seguir</>;
       default:
         return "Nova notificação";
     }
@@ -246,14 +267,10 @@ export default function Notificacao() {
 
   const avatarClass = (tipo) => {
     const map = {
-      seguindo: "seguidor",
-      curtida: "curtida",
+      seguindo:   "seguidor",
+      curtida:    "curtida",
       comentario: "comentario",
-      mensagem: "mensagem",
-      solicitacao_seguir: "seguidor",
-      solicitacao_aceita_seguidor: "seguidor",
-      solicitacao_aceita_chat: "seguidor",
-      solicitacao_recusada: "seguidor",
+      mensagem:   "mensagem",
     };
     return map[tipo] || "seguidor";
   };
@@ -265,29 +282,18 @@ export default function Notificacao() {
     const base = notificacoes.filter((n) => !n.lida);
     if (tipo === "todas") return base.length;
     if (tipo === "arquivadas") return 0;
-    // Incluir todos os tipos de seguidores
-    if (tipo === "seguindo") {
-      return base.filter((n) =>
-        ["seguindo", "solicitacao_seguir", "solicitacao_aceita_seguidor", "solicitacao_aceita_chat", "solicitacao_recusada"].includes(n.tipo)
-      ).length;
-    }
+    if (tipo === "seguindo") return base.filter((n) => n.tipo === "seguindo").length;
     return base.filter((n) => n.tipo === tipo).length;
   };
 
-  // ── FILTRO ──
   const filtrarNotificacoes = () => {
     if (filtro === "arquivadas") return [];
     if (filtro === "todas") return notificacoes;
-    if (filtro === "seguindo") {
-      return notificacoes.filter((n) =>
-        ["seguindo", "solicitacao_seguir", "solicitacao_aceita_seguidor", "solicitacao_aceita_chat", "solicitacao_recusada"].includes(n.tipo)
-      );
-    }
     return notificacoes.filter((n) => n.tipo === filtro);
   };
 
   const notifFiltradas = filtrarNotificacoes();
-  const hoje = notifFiltradas.filter((n) => isHoje(n.createdAt));
+  const hoje      = notifFiltradas.filter((n) =>  isHoje(n.createdAt));
   const anteriores = notifFiltradas.filter((n) => !isHoje(n.createdAt));
   const estaEmArquivadas = filtro === "arquivadas";
 
@@ -346,8 +352,9 @@ export default function Notificacao() {
                         onExcluir={excluirNotificacao}
                         timersRef={timersRef}
                         tempoArquivarMs={TEMPO_ARQUIVAR_MS}
-                        onAceitarSeguidor={aceitarSeguidor}
-                        onRecusar={recusarSolicitacao}
+                        jaSeguindo={seguindoMap[n.de_id] || false}
+                        onSeguirDeVolta={seguirDeVolta}
+                        onDeixarDeSeguir={deixarDeSeguirNotif}
                       />
                     ))}
                   </div>
@@ -369,8 +376,9 @@ export default function Notificacao() {
                         onExcluir={excluirNotificacao}
                         timersRef={timersRef}
                         tempoArquivarMs={TEMPO_ARQUIVAR_MS}
-                        onAceitarSeguidor={aceitarSeguidor}
-                        onRecusar={recusarSolicitacao}
+                        jaSeguindo={seguindoMap[n.de_id] || false}
+                        onSeguirDeVolta={seguirDeVolta}
+                        onDeixarDeSeguir={deixarDeSeguirNotif}
                       />
                     ))}
                   </div>
@@ -384,6 +392,7 @@ export default function Notificacao() {
               )}
             </>
           )}
+
           {estaEmArquivadas && (
             <>
               <div className="arquivo-aviso">
@@ -416,6 +425,7 @@ export default function Notificacao() {
           )}
         </div>
       </div>
+
       {!estaEmArquivadas && (
         <button className="fab-marcar" onClick={marcarTodasComoLidas}>
           <span className="material-symbols-outlined">done_all</span>
@@ -426,7 +436,7 @@ export default function Notificacao() {
   );
 }
 
-// Componente CardNotificacao
+// ── Card de Notificação ──
 function CardNotificacao({
   n,
   avatarClass,
@@ -438,12 +448,15 @@ function CardNotificacao({
   timersRef,
   tempoArquivarMs,
   isArquivada = false,
-  onAceitarSeguidor,
-  onRecusar,
+  jaSeguindo = false,
+  onSeguirDeVolta,
+  onDeixarDeSeguir,
 }) {
   const tipoClass = avatarClass(n.tipo);
   const [segundosRestantes, setSegundosRestantes] = useState(null);
-  const isSolicitacao = n.tipo === "solicitacao_seguir";
+  const [loadingFollow, setLoadingFollow] = useState(false);
+
+  const ehSeguindo = n.tipo === "seguindo";
 
   useEffect(() => {
     if (!n.lida || isArquivada || !timersRef) return;
@@ -452,10 +465,7 @@ function CardNotificacao({
     setSegundosRestantes(totalSeg);
     const interval = setInterval(() => {
       setSegundosRestantes((prev) => {
-        if (prev === null || prev <= 1) {
-          clearInterval(interval);
-          return null;
-        }
+        if (prev === null || prev <= 1) { clearInterval(interval); return null; }
         return prev - 1;
       });
     }, 1000);
@@ -469,6 +479,21 @@ function CardNotificacao({
     return m > 0 ? `${m}m ${s}s` : `${s}s`;
   };
 
+  const handleFollow = async (e) => {
+    e.stopPropagation();
+    if (loadingFollow) return;
+    setLoadingFollow(true);
+    try {
+      if (jaSeguindo) {
+        await onDeixarDeSeguir(n);
+      } else {
+        await onSeguirDeVolta(n);
+      }
+    } finally {
+      setLoadingFollow(false);
+    }
+  };
+
   return (
     <div
       className={`notif-card ${n.lida ? "lida" : "nao-lida"} ${isArquivada ? "arquivada" : ""}`}
@@ -480,6 +505,7 @@ function CardNotificacao({
           <span className="material-symbols-outlined">{tipoIcone(n.tipo)}</span>
         </span>
       </div>
+
       <div className="notif-content">
         <p className="notif-text">{renderTexto(n)}</p>
         <div className="notif-meta">
@@ -487,32 +513,38 @@ function CardNotificacao({
           <span className="notif-time">{tempoRelativo(n.createdAt)}</span>
           {n.lida && !isArquivada && segundosRestantes !== null && (
             <span className="notif-arquivando">
-              <span className="material-symbols-outlined" style={{ fontSize: 11 }}>
-                schedule
-              </span>
+              <span className="material-symbols-outlined" style={{ fontSize: 11 }}>schedule</span>
               arquivando em {formatarContagem(segundosRestantes)}
             </span>
           )}
         </div>
-        {isSolicitacao && !isArquivada && (
+
+        {/* Botão "Seguir de volta" — apenas em notificações do tipo seguindo, não arquivadas */}
+        {ehSeguindo && !isArquivada && (
           <div className="notif-toast__acoes" style={{ marginTop: 8 }}>
             <button
-              className="notif-toast__btn notif-toast__btn--seguindo"
-              onClick={(e) => { e.stopPropagation(); onAceitarSeguidor(n); }}
+              className={`notif-toast__btn ${jaSeguindo ? "notif-btn-seguindo-ativo" : "notif-toast__btn--seguindo"}`}
+              onClick={handleFollow}
+              disabled={loadingFollow}
             >
-              <span className="material-symbols-outlined">person_add</span>
-              Aceitar
-            </button>
-            <button
-              className="notif-toast__btn notif-toast__btn--curtida"
-              onClick={(e) => { e.stopPropagation(); onRecusar(n); }}
-            >
-              <span className="material-symbols-outlined">close</span>
-              Recusar
+              {loadingFollow ? (
+                <span className="material-symbols-outlined">hourglass_empty</span>
+              ) : jaSeguindo ? (
+                <>
+                  <span className="material-symbols-outlined">person_check</span>
+                  Seguindo
+                </>
+              ) : (
+                <>
+                  <span className="material-symbols-outlined">person_add</span>
+                  Seguir de volta
+                </>
+              )}
             </button>
           </div>
         )}
       </div>
+
       <div className="notif-actions">
         <button
           className="btn-excluir"
@@ -528,14 +560,10 @@ function CardNotificacao({
 
 function tipoIcone(tipo) {
   switch (tipo) {
-    case "seguindo": return "person_add";
-    case "curtida": return "favorite";
+    case "seguindo":   return "person_add";
+    case "curtida":    return "favorite";
     case "comentario": return "chat_bubble";
-    case "mensagem": return "send";
-    case "solicitacao_seguir": return "person_add";
-    case "solicitacao_aceita_seguidor": return "person_add";
-    case "solicitacao_aceita_chat": return "chat";
-    case "solicitacao_recusada": return "person_remove";
-    default: return "notifications";
+    case "mensagem":   return "send";
+    default:           return "notifications";
   }
 }

--- a/src/pages/Perfil/perfil.jsx
+++ b/src/pages/Perfil/perfil.jsx
@@ -94,7 +94,7 @@ export default function Perfil() {
     setChatLiberado(false);
   }, [id, user?.uid]);
 
-  // 🔥 FIRESTORE REALTIME
+  // 🔥 FIRESTORE REALTIME — isFollowing derivado aqui, sem useEffect separado
   useEffect(() => {
     if (!user && !id) return;
     const userId = id || user?.uid;
@@ -111,6 +111,13 @@ export default function Perfil() {
         setFotoPerfil(data.fotoPerfil || "");
         setBanner(data.banner || null);
         setCarregando(false);
+
+        // Deriva isFollowing aqui — sem useEffect separado, sem flash
+        if (user && docSnap.id !== user.uid) {
+          const seguidores = data.seguidores || [];
+          setIsFollowing(seguidores.includes(user.uid));
+        }
+
         localStorage.setItem(
           `perfilCache_${docSnap.id}`,
           JSON.stringify({ uid: docSnap.id, ...data })
@@ -120,12 +127,7 @@ export default function Perfil() {
     return unsubscribe;
   }, [id, user]);
 
-  // Ver se segue
-  useEffect(() => {
-    if (!user || !usuarioPerfil) return;
-    const seguidores = usuarioPerfil.seguidores || [];
-    setIsFollowing(seguidores.includes(user.uid));
-  }, [user, usuarioPerfil]);
+  // useEffect de isFollowing removido — agora derivado dentro do onSnapshot acima
 
   // Escuta em tempo real o status da solicitação pendente
   useEffect(() => {
@@ -153,16 +155,15 @@ export default function Perfil() {
     return unsub;
   }, [user, usuarioPerfil, isFollowing, isOwnProfile]);
 
-  // ⭐ Verifica permissão de chat
+  // ⭐ Chat liberado se A segue B OU B segue A — sem chat_permissions
   useEffect(() => {
     if (!user || !usuarioPerfil || isOwnProfile) return;
-    const chatId = [user.uid, usuarioPerfil.id].sort().join("_");
-    const checkPermission = async () => {
-      const snap = await getDoc(doc(db, "chat_permissions", chatId));
-      setChatLiberado(snap.exists() && snap.data().accepted === true);
-    };
-    checkPermission();
-  }, [user, usuarioPerfil, isOwnProfile]);
+
+    // B segue A = B está nos seguidores de B (usuarioPerfil.seguidores contém user.uid)
+    const bSegueA = (usuarioPerfil.seguidores || []).includes(user.uid);
+    // A segue B = isFollowing
+    setChatLiberado(isFollowing || bSegueA);
+  }, [user, usuarioPerfil, isOwnProfile, isFollowing]);
 
   const cancelarSolicitacao = async () => {
     if (!user || !usuarioPerfil) return;

--- a/src/pages/Perfil/perfil.jsx
+++ b/src/pages/Perfil/perfil.jsx
@@ -15,8 +15,12 @@ import {
   addDoc,
   collection,
   getDoc,
+  getDocs,
   setDoc,
   serverTimestamp,
+  query,
+  where,
+  deleteDoc,
 } from "firebase/firestore";
 
 import {
@@ -42,6 +46,9 @@ export default function Perfil() {
 
   const [abaSelecionada, setAbaSelecionada] = useState("Galeria");
   const [isFollowing, setIsFollowing] = useState(false);
+  // null = ainda verificando | "nenhuma" | "pendente" | "aceito"
+  const [statusSolicitacao, setStatusSolicitacao] = useState(null);
+  const [chatLiberado, setChatLiberado] = useState(false); // ⭐ novo estado
 
   const postInputRef = useRef(null);
 
@@ -53,33 +60,28 @@ export default function Perfil() {
 
   const isOwnProfile = !id || id === user?.uid;
 
-  // =========================
-  // ⚡ CACHE + SKELETON ao trocar de perfil
-  // =========================
+  // ⚡ CACHE + SKELETON
   useEffect(() => {
     const targetId = id || user?.uid;
     if (!targetId) return;
 
-    // Tenta aplicar cache instantaneamente
     const cache = localStorage.getItem(`perfilCache_${targetId}`);
     if (cache) {
       try {
         const dados = JSON.parse(cache);
-        // Cache hit: aplica dados imediatamente e não mostra skeleton
         setUsuarioPerfil((prev) => ({ ...prev, ...dados }));
         setBio(dados.bio || "");
         setLocalizacao(dados.localizacao || "");
         setFotoPerfil(dados.fotoPerfil || "");
         setBanner(dados.banner || null);
         setPosts(dados.posts || []);
-        setCarregando(false); // tem cache → sem skeleton
+        setCarregando(false);
         return;
       } catch {
         localStorage.removeItem(`perfilCache_${targetId}`);
       }
     }
 
-    // Cache miss: mostra skeleton e limpa dados do perfil anterior
     setCarregando(true);
     setUsuarioPerfil(null);
     setFotoPerfil("");
@@ -88,81 +90,140 @@ export default function Perfil() {
     setLocalizacao("");
     setPosts([]);
     setIsFollowing(false);
+    setStatusSolicitacao(null);
+    setChatLiberado(false);
   }, [id, user?.uid]);
 
-  // =========================
   // 🔥 FIRESTORE REALTIME
-  // =========================
   useEffect(() => {
     if (!user && !id) return;
-
     const userId = id || user?.uid;
     if (!userId) return;
 
     const docRef = doc(db, "usuarios", userId);
-
     const unsubscribe = onSnapshot(docRef, (docSnap) => {
       if (docSnap.exists()) {
         const data = docSnap.data();
-
         setUsuarioPerfil({ id: docSnap.id, ...data });
         setPosts(data.posts || []);
         setBio(data.bio || "");
         setLocalizacao(data.localizacao || "");
         setFotoPerfil(data.fotoPerfil || "");
         setBanner(data.banner || null);
-        setCarregando(false); // Firestore respondeu — esconde o skeleton
-
-        // Salva cache por uid — na próxima visita carrega instantâneo sem skeleton
+        setCarregando(false);
         localStorage.setItem(
           `perfilCache_${docSnap.id}`,
           JSON.stringify({ uid: docSnap.id, ...data })
         );
       }
     });
-
     return unsubscribe;
   }, [id, user]);
 
-  // 🔍 VER SE SEGUE
+  // Ver se segue
   useEffect(() => {
     if (!user || !usuarioPerfil) return;
     const seguidores = usuarioPerfil.seguidores || [];
     setIsFollowing(seguidores.includes(user.uid));
   }, [user, usuarioPerfil]);
 
-  // ➕ SEGUIR
+  // Escuta em tempo real o status da solicitação pendente
+  useEffect(() => {
+    if (!user || !usuarioPerfil || isOwnProfile) return;
+
+    // Se já é seguidor confirmado, status é aceito
+    if (isFollowing) {
+      setStatusSolicitacao("aceito");
+      return;
+    }
+
+    const q = query(
+      collection(db, "notificacoes"),
+      where("tipo",  "==", "solicitacao_seguir"),
+      where("de_id", "==", user.uid),
+      where("para",  "==", usuarioPerfil.id)
+    );
+
+    // onSnapshot: atualiza ao vivo quando B aceita, recusa ou A cancela
+    const unsub = onSnapshot(q, (snap) => {
+      const pendente = snap.docs.some((d) => d.data().status === "pendente");
+      setStatusSolicitacao(pendente ? "pendente" : "nenhuma");
+    });
+
+    return unsub;
+  }, [user, usuarioPerfil, isFollowing, isOwnProfile]);
+
+  // ⭐ Verifica permissão de chat
+  useEffect(() => {
+    if (!user || !usuarioPerfil || isOwnProfile) return;
+    const chatId = [user.uid, usuarioPerfil.id].sort().join("_");
+    const checkPermission = async () => {
+      const snap = await getDoc(doc(db, "chat_permissions", chatId));
+      setChatLiberado(snap.exists() && snap.data().accepted === true);
+    };
+    checkPermission();
+  }, [user, usuarioPerfil, isOwnProfile]);
+
+  const cancelarSolicitacao = async () => {
+    if (!user || !usuarioPerfil) return;
+    try {
+      // Remove B do array "seguindo" de A
+      await updateDoc(doc(db, "usuarios", user.uid), {
+        seguindo: arrayRemove(usuarioPerfil.id),
+      });
+      // Deleta a notificação pendente — o onSnapshot atualiza statusSolicitacao automaticamente
+      const q = query(
+        collection(db, "notificacoes"),
+        where("tipo",  "==", "solicitacao_seguir"),
+        where("de_id", "==", user.uid),
+        where("para",  "==", usuarioPerfil.id)
+      );
+      const snap = await getDocs(q);
+      await Promise.all(snap.docs.map((d) => deleteDoc(d.ref)));
+      // Estado local imediato — listener confirma em seguida
+      setStatusSolicitacao("nenhuma");
+    } catch (error) {
+      console.error("Erro ao cancelar solicitação:", error);
+    }
+  };
+
   const seguir = async () => {
     if (!user || !usuarioPerfil) return;
-
     await updateDoc(doc(db, "usuarios", user.uid), {
       seguindo: arrayUnion(usuarioPerfil.id),
     });
-    await updateDoc(doc(db, "usuarios", usuarioPerfil.id), {
-      seguidores: arrayUnion(user.uid),
-    });
     await addDoc(collection(db, "notificacoes"), {
-      tipo: "seguindo",
+      tipo: "solicitacao_seguir",
       de: user.displayName || "Pescador",
-      deId: user.uid,
+      de_id: user.uid,
       para: usuarioPerfil.id,
+      status: "pendente",
+      lida: false,
       createdAt: serverTimestamp(),
     });
+    setStatusSolicitacao("pendente");
   };
 
-  // ➖ DEIXAR DE SEGUIR
   const deixarDeSeguir = async () => {
     if (!user || !usuarioPerfil) return;
-
     await updateDoc(doc(db, "usuarios", user.uid), {
       seguindo: arrayRemove(usuarioPerfil.id),
     });
     await updateDoc(doc(db, "usuarios", usuarioPerfil.id), {
       seguidores: arrayRemove(user.uid),
     });
+    const q = query(
+      collection(db, "notificacoes"),
+      where("tipo", "==", "solicitacao_seguir"),
+      where("de_id", "==", user.uid),
+      where("para", "==", usuarioPerfil.id)
+    );
+    const snap = await getDocs(q);
+    await Promise.all(snap.docs.map((d) => deleteDoc(d.ref)));
+    setStatusSolicitacao("nenhuma");
+    setIsFollowing(false);
   };
 
-  // 💬 CHAT
   const gerarChatId = (id1, id2) => [id1, id2].sort().join("_");
 
   const irParaChat = async () => {
@@ -175,13 +236,11 @@ export default function Perfil() {
     navigate(`/chat/${chatId}`);
   };
 
-  // 💾 SALVAR POSTS
   const salvarPosts = async (novosPosts) => {
     if (!usuarioPerfil?.id) return;
     await updateDoc(doc(db, "usuarios", usuarioPerfil.id), { posts: novosPosts });
   };
 
-  // 🖼️ FOTO DE PERFIL
   const handleFotoChange = async (file) => {
     if (!isOwnProfile || !usuarioPerfil?.id) return;
     const reader = new FileReader();
@@ -198,7 +257,6 @@ export default function Perfil() {
     reader.readAsDataURL(file);
   };
 
-  // 🌄 BANNER
   const handleBannerChange = async (file) => {
     if (!isOwnProfile || !usuarioPerfil?.id) return;
     const reader = new FileReader();
@@ -215,17 +273,13 @@ export default function Perfil() {
     reader.readAsDataURL(file);
   };
 
-  // 📸 NOVO POST
   const handlePostChange = (e) => {
     const file = e.target.files[0];
     if (!file) return;
-
     let comentario = prompt("Descrição:");
     if (comentario === null) return;
-
     let local = prompt("Local:");
     if (local === null) return;
-
     const reader = new FileReader();
     reader.onload = () => {
       const novoPost = {
@@ -248,10 +302,7 @@ export default function Perfil() {
       <Layout>
         <div className="container2">
           <div className="perfil perfil-skeleton">
-            {/* Banner skeleton */}
             <div className="sk sk-banner" />
-
-            {/* Linha foto + botões */}
             <div className="sk-inferior">
               <div className="sk sk-avatar" />
               <div className="sk-botoes">
@@ -259,22 +310,16 @@ export default function Perfil() {
                 <div className="sk sk-btn" />
               </div>
             </div>
-
-            {/* Info skeleton */}
             <div className="sk-info">
               <div className="sk sk-nome" />
               <div className="sk sk-linha" />
               <div className="sk sk-linha sk-linha--curta" />
             </div>
-
-            {/* Stats skeleton */}
             <div className="sk-stats">
               <div className="sk sk-stat" />
               <div className="sk sk-stat" />
               <div className="sk sk-stat" />
             </div>
-
-            {/* Grid skeleton */}
             <div className="sk-grid">
               {Array.from({ length: 6 }).map((_, i) => (
                 <div key={i} className="sk sk-grid-item" />
@@ -302,8 +347,11 @@ export default function Perfil() {
             onFotoChange={handleFotoChange}
             onBannerChange={handleBannerChange}
             isFollowing={isFollowing}
+            statusSolicitacao={statusSolicitacao}
+            chatLiberado={chatLiberado}   // ⭐ novo prop
             onSeguir={seguir}
             onDeixarDeSeguir={deixarDeSeguir}
+            onCancelarSolicitacao={cancelarSolicitacao}
             onMensagem={irParaChat}
           />
 
@@ -324,31 +372,31 @@ export default function Perfil() {
             onTrocarAba={setAbaSelecionada}
           />
 
-{abaSelecionada === "Galeria" && (
-  <GaleriaPerfil
-    posts={posts}
-    user={user}
-    usuarioPerfil={usuarioPerfil}
-    salvarPosts={salvarPosts}
-    navigate={navigate}
-  />
-)}
+          {abaSelecionada === "Galeria" && (
+            <GaleriaPerfil
+              posts={posts}
+              user={user}
+              usuarioPerfil={usuarioPerfil}
+              salvarPosts={salvarPosts}
+              navigate={navigate}
+            />
+          )}
 
-{abaSelecionada === "Equipamentos" && (
-  <div className="aba-em-breve">
-    <span className="material-symbols-outlined">construction</span>
-    <p>Equipamentos</p>
-    <span>Recursos para gerenciar seus equipamentos de pesca estarão aqui.</span>
-  </div>
-)}
+          {abaSelecionada === "Equipamentos" && (
+            <div className="aba-em-breve">
+              <span className="material-symbols-outlined">construction</span>
+              <p>Equipamentos</p>
+              <span>Recursos para gerenciar seus equipamentos de pesca estarão aqui.</span>
+            </div>
+          )}
 
-{abaSelecionada === "Locais Salvos" && (
-  <div className="aba-em-breve">
-    <span className="material-symbols-outlined">bookmark</span>
-    <p>Locais Salvos</p>
-    <span>Seus pontos de pesca favoritos aparecerão nesta seção.</span>
-  </div>
-)}
+          {abaSelecionada === "Locais Salvos" && (
+            <div className="aba-em-breve">
+              <span className="material-symbols-outlined">bookmark</span>
+              <p>Locais Salvos</p>
+              <span>Seus pontos de pesca favoritos aparecerão nesta seção.</span>
+            </div>
+          )}
         </div>
       </div>
     </Layout>

--- a/src/pages/Perfil/perfil.jsx
+++ b/src/pages/Perfil/perfil.jsx
@@ -15,11 +15,11 @@ import {
   addDoc,
   collection,
   getDoc,
-  getDocs,
   setDoc,
   serverTimestamp,
   query,
   where,
+  getDocs,
   deleteDoc,
 } from "firebase/firestore";
 
@@ -46,9 +46,6 @@ export default function Perfil() {
 
   const [abaSelecionada, setAbaSelecionada] = useState("Galeria");
   const [isFollowing, setIsFollowing] = useState(false);
-  // null = ainda verificando | "nenhuma" | "pendente" | "aceito"
-  const [statusSolicitacao, setStatusSolicitacao] = useState(null);
-  const [chatLiberado, setChatLiberado] = useState(false); // ⭐ novo estado
 
   const postInputRef = useRef(null);
 
@@ -90,11 +87,9 @@ export default function Perfil() {
     setLocalizacao("");
     setPosts([]);
     setIsFollowing(false);
-    setStatusSolicitacao(null);
-    setChatLiberado(false);
   }, [id, user?.uid]);
 
-  // 🔥 FIRESTORE REALTIME — isFollowing derivado aqui, sem useEffect separado
+  // 🔥 FIRESTORE REALTIME
   useEffect(() => {
     if (!user && !id) return;
     const userId = id || user?.uid;
@@ -112,7 +107,7 @@ export default function Perfil() {
         setBanner(data.banner || null);
         setCarregando(false);
 
-        // Deriva isFollowing aqui — sem useEffect separado, sem flash
+        // Deriva isFollowing direto do snapshot — sem flash
         if (user && docSnap.id !== user.uid) {
           const seguidores = data.seguidores || [];
           setIsFollowing(seguidores.includes(user.uid));
@@ -127,101 +122,56 @@ export default function Perfil() {
     return unsubscribe;
   }, [id, user]);
 
-  // useEffect de isFollowing removido — agora derivado dentro do onSnapshot acima
-
-  // Escuta em tempo real o status da solicitação pendente
-  useEffect(() => {
-    if (!user || !usuarioPerfil || isOwnProfile) return;
-
-    // Se já é seguidor confirmado, status é aceito
-    if (isFollowing) {
-      setStatusSolicitacao("aceito");
-      return;
-    }
-
-    const q = query(
-      collection(db, "notificacoes"),
-      where("tipo",  "==", "solicitacao_seguir"),
-      where("de_id", "==", user.uid),
-      where("para",  "==", usuarioPerfil.id)
-    );
-
-    // onSnapshot: atualiza ao vivo quando B aceita, recusa ou A cancela
-    const unsub = onSnapshot(q, (snap) => {
-      const pendente = snap.docs.some((d) => d.data().status === "pendente");
-      setStatusSolicitacao(pendente ? "pendente" : "nenhuma");
-    });
-
-    return unsub;
-  }, [user, usuarioPerfil, isFollowing, isOwnProfile]);
-
-  // ⭐ Chat liberado se A segue B OU B segue A — sem chat_permissions
-  useEffect(() => {
-    if (!user || !usuarioPerfil || isOwnProfile) return;
-
-    // B segue A = B está nos seguidores de B (usuarioPerfil.seguidores contém user.uid)
+  // ⭐ Chat liberado se A segue B OU B segue A
+  const chatLiberado = (() => {
+    if (!user || !usuarioPerfil || isOwnProfile) return false;
     const bSegueA = (usuarioPerfil.seguidores || []).includes(user.uid);
-    // A segue B = isFollowing
-    setChatLiberado(isFollowing || bSegueA);
-  }, [user, usuarioPerfil, isOwnProfile, isFollowing]);
+    return isFollowing || bSegueA;
+  })();
 
-  const cancelarSolicitacao = async () => {
-    if (!user || !usuarioPerfil) return;
-    try {
-      // Remove B do array "seguindo" de A
-      await updateDoc(doc(db, "usuarios", user.uid), {
-        seguindo: arrayRemove(usuarioPerfil.id),
-      });
-      // Deleta a notificação pendente — o onSnapshot atualiza statusSolicitacao automaticamente
-      const q = query(
-        collection(db, "notificacoes"),
-        where("tipo",  "==", "solicitacao_seguir"),
-        where("de_id", "==", user.uid),
-        where("para",  "==", usuarioPerfil.id)
-      );
-      const snap = await getDocs(q);
-      await Promise.all(snap.docs.map((d) => deleteDoc(d.ref)));
-      // Estado local imediato — listener confirma em seguida
-      setStatusSolicitacao("nenhuma");
-    } catch (error) {
-      console.error("Erro ao cancelar solicitação:", error);
-    }
-  };
-
+  // ── SEGUIR (direto, sem solicitação) ──
   const seguir = async () => {
     if (!user || !usuarioPerfil) return;
+
+    // Adiciona B nos seguidores de A imediatamente
     await updateDoc(doc(db, "usuarios", user.uid), {
       seguindo: arrayUnion(usuarioPerfil.id),
     });
+    // Adiciona A nos seguidores do perfil B
+    await updateDoc(doc(db, "usuarios", usuarioPerfil.id), {
+      seguidores: arrayUnion(user.uid),
+    });
+    // Notifica B — tipo "seguindo", com botão de seguir de volta
     await addDoc(collection(db, "notificacoes"), {
-      tipo: "solicitacao_seguir",
+      tipo: "seguindo",
       de: user.displayName || "Pescador",
       de_id: user.uid,
       para: usuarioPerfil.id,
-      status: "pendente",
       lida: false,
       createdAt: serverTimestamp(),
     });
-    setStatusSolicitacao("pendente");
   };
 
+  // ── DEIXAR DE SEGUIR ──
   const deixarDeSeguir = async () => {
     if (!user || !usuarioPerfil) return;
+
     await updateDoc(doc(db, "usuarios", user.uid), {
       seguindo: arrayRemove(usuarioPerfil.id),
     });
     await updateDoc(doc(db, "usuarios", usuarioPerfil.id), {
       seguidores: arrayRemove(user.uid),
     });
+    // Remove notificação de "seguindo" que A enviou para B, se existir
     const q = query(
       collection(db, "notificacoes"),
-      where("tipo", "==", "solicitacao_seguir"),
+      where("tipo", "==", "seguindo"),
       where("de_id", "==", user.uid),
       where("para", "==", usuarioPerfil.id)
     );
     const snap = await getDocs(q);
     await Promise.all(snap.docs.map((d) => deleteDoc(d.ref)));
-    setStatusSolicitacao("nenhuma");
+
     setIsFollowing(false);
   };
 
@@ -348,17 +298,18 @@ export default function Perfil() {
             onFotoChange={handleFotoChange}
             onBannerChange={handleBannerChange}
             isFollowing={isFollowing}
-            statusSolicitacao={statusSolicitacao}
-            chatLiberado={chatLiberado}   // ⭐ novo prop
+            chatLiberado={chatLiberado}
             onSeguir={seguir}
             onDeixarDeSeguir={deixarDeSeguir}
-            onCancelarSolicitacao={cancelarSolicitacao}
             onMensagem={irParaChat}
+            currentUserId={user?.uid}
           />
 
           <EstatisticasPerfil
             totalPosts={posts.length}
             usuario={usuarioPerfil}
+            currentUserId={user?.uid}
+            isOwnProfile={isOwnProfile}
           />
 
           <input

--- a/src/pages/chat/Chat.jsx
+++ b/src/pages/chat/Chat.jsx
@@ -145,7 +145,8 @@ export default function Chat() {
   }, [chatId]);
 
   // =========================
-  // 🔒 Permissão + Dados do Outro Usuário
+  // 🔒 Permissão + dados do outro usuário
+  // Chat liberado se A segue B ou B segue A
   // =========================
   useEffect(() => {
     if (!user || !chatId) {
@@ -155,26 +156,12 @@ export default function Chat() {
 
     setPermitido(null);
 
-    const verificar = async () => {
+    const ids = chatId.split("_");
+    const outroId = ids.find((id) => id !== user.uid);
+
+    // Carrega dados do outro usuário (one-shot)
+    const carregarOutroUsuario = async () => {
       try {
-        const ids = chatId.split("_");
-        const outroId = ids.find((id) => id !== user.uid);
-
-        const meuDoc = await getDoc(doc(db, "usuarios", user.uid));
-        if (!meuDoc.exists()) {
-          setPermitido(false);
-          setLoadingMessages(false);
-          return;
-        }
-
-        const dados = meuDoc.data();
-        const autorizado =
-          dados?.seguindo?.includes(outroId) ||
-          dados?.seguidores?.includes(outroId);
-
-        setPermitido(autorizado);
-        if (!autorizado) setLoadingMessages(false);
-
         const outroDoc = await getDoc(doc(db, "usuarios", outroId));
         if (outroDoc.exists()) {
           const outro = outroDoc.data();
@@ -183,6 +170,34 @@ export default function Chat() {
             foto: outro?.fotoPerfil || "",
           });
         }
+      } catch (e) {
+        console.error("Erro ao carregar outro usuário:", e);
+      }
+    };
+
+    carregarOutroUsuario();
+
+    // Permissão: liberado se A segue B ou B segue A
+    // Sem chat_permissions — qualquer relacionamento de seguir libera o chat
+    const verificarPermissao = async () => {
+      try {
+        const meuDoc   = await getDoc(doc(db, "usuarios", user.uid));
+        const outroDoc = await getDoc(doc(db, "usuarios", outroId));
+
+        if (!meuDoc.exists() || !outroDoc.exists()) {
+          setPermitido(false);
+          setLoadingMessages(false);
+          return;
+        }
+
+        const meusDados   = meuDoc.data();
+        const outrosDados = outroDoc.data();
+
+        const euSigoEle  = (meusDados.seguindo   || []).includes(outroId);
+        const eleSegueEu = (outrosDados.seguindo  || []).includes(user.uid);
+
+        setPermitido(euSigoEle || eleSegueEu);
+        if (!euSigoEle && !eleSegueEu) setLoadingMessages(false);
       } catch (error) {
         console.error("Erro ao verificar permissão:", error);
         setPermitido(false);
@@ -190,7 +205,9 @@ export default function Chat() {
       }
     };
 
-    verificar();
+    verificarPermissao();
+
+    return () => {};
   }, [user, chatId]);
 
   // =========================
@@ -255,7 +272,7 @@ export default function Chat() {
   // ✉️ Enviar Mensagem
   // =========================
   const enviarMensagem = async () => {
-    if (!texto.trim() || enviando) return;
+    if (!texto.trim() || enviando || !permitido) return;
     setEnviando(true);
 
     try {
@@ -518,7 +535,9 @@ export default function Chat() {
                   🔒
                 </div>
                 <p>Chat bloqueado</p>
-                <span>Você precisa seguir este usuário para conversar.</span>
+                <span>
+                  Siga este pescador ou aguarde ele te seguir para conversar.
+                </span>
                 <button
                   className="btn-voltar-bloqueio"
                   onClick={() => navigate("/chat")}


### PR DESCRIPTION
# feat(seguir): refatora lógica de seguir, remove sistema de solicitação e implementa seguimento direto com “seguir de volta”

## Resumo
Este PR refatora completamente o fluxo de seguir/aceitar entre usuários. Inicialmente foi adicionado um sistema com solicitação de seguir, notificação e aceite via chat, mas posteriormente o fluxo foi **simplificado e substituído por seguimento direto** (sem necessidade de aprovação). Também foram adicionados botões **“seguir de volta”** nas notificações e no modal de seguidores, além da simplificação dos botões de ação no cabeçalho do perfil.

## Principais alterações

### Evolução do fluxo (histórico de commits)
- **Adição inicial**: sistema de solicitação de seguir, notificações e aceite de chat.
- **Simplificação**: refatoração para tornar o fluxo mais direto.
- **Estado final (implementado)**:
  - **Remoção completa do sistema de solicitação** – agora seguir é **imediato e direto** (sem pendência).
  - **Seguimento direto** – qualquer usuário pode seguir outro instantaneamente.

### Novas funcionalidades (estado final)
- **Botão “seguir de volta”** na tela de notificações, para cards do tipo “seguindo” – facilita retribuir follow.
- **Botões seguir/seguindo adicionados ao modal de seguidores** na página de estatísticas do perfil.
- **CSS dos botões de seguir de volta** com suporte a **dark mode**.

### Refatorações de UI
- **Cabeçalho do perfil**: removidos estados `pendente` e `cancelar` (já que não há mais solicitação). Botões de ação simplificados (apenas “seguir” ou “seguindo” com opção de deixar de seguir).

## Commits relacionados
- `feat: solicitação de seguir, notificações e aceite de chat`
- `refactor(follow-chat): simplifica fluxo de solicitação de seguir e chat`
- `feat(perfil): remove sistema de solicitação e implementa seguimento direto`
- `feat(notificacao): adiciona botão "seguir de volta" no card de tipo seguindo`
- `feat(estatisticas-perfil): adiciona botão seguir/seguindo no modal de seguidores`
- `refactor(cabecalho-perfil): remove estados pendente/cancelar, simplifica botões de ação`
- `style(seguir-de-volta): adiciona CSS dos botões seguir de volta com dark mode`

## Testes sugeridos
1. **Seguir diretamente** – acessar perfil de outro usuário → clicar em “Seguir” → deve seguir imediatamente (sem solicitação). O botão muda para “Seguindo” e permite deixar de seguir.
2. **Seguir de volta via notificação** – receber uma notificação de que alguém começou a seguir você → o card deve ter botão “Seguir de volta” → clicar e confirmar que passa a seguir a pessoa.
3. **Modal de seguidores** – abrir estatísticas do perfil, clicar em “Seguidores” → cada item deve ter botão “Seguir” (ou “Seguindo”) → ação deve funcionar em tempo real.
4. **Notificações de seguir** – após seguir alguém, a outra pessoa deve receber notificação (card tipo “seguindo”).
5. **Dark mode** – verificar cores dos botões “Seguir de volta” e dos botões no modal em tema escuro.
6. **Cabeçalho do perfil** – em perfil de outro usuário, não deve haver estado “Pendente” ou “Cancelar solicitação” – apenas seguir/seguindo.
7. **Consistência com chat** – a remoção do sistema de solicitação não deve quebrar o chat privado (acesso ao chat deve ser livre ou seguir regra anterior? Confirmar que não gerou erro).

## Observações
- A mudança de **solicitação para seguimento direto** simplifica a experiência, tornando-a similar a redes sociais como Instagram (follow imediato).
- O botão “seguir de volta” acelera interações recíprocas.
- Este PR elimina complexidades desnecessárias (estados pendente, aceite via chat) e melhora a consistência da interface.