### PR TITLE
Feature/chat perfil clicavel

### DIFF
--- a/src/pages/chat/Chat.jsx
+++ b/src/pages/chat/Chat.jsx
@@ -76,7 +76,7 @@ export default function Chat() {
         const q = query(
           collection(db, "chats", cid, "mensagens"),
           orderBy("createdAt", "desc"),
-          limit(1)
+          limit(1),
         );
 
         const unsubscribe = onSnapshot(q, async (snapshot) => {
@@ -91,11 +91,11 @@ export default function Chat() {
 
           const qNaoLidas = query(
             collection(db, "chats", cid, "mensagens"),
-            where("userId", "!=", user.uid)
+            where("userId", "!=", user.uid),
           );
           const snapNaoLidas = await getDocs(qNaoLidas);
           const naoLidas = snapNaoLidas.docs.filter(
-            (d) => d.data().status !== "visto"
+            (d) => d.data().status !== "visto",
           ).length;
 
           const userDoc = await getDoc(doc(db, "usuarios", id));
@@ -167,7 +167,7 @@ export default function Chat() {
         if (outroDoc.exists()) {
           const outro = outroDoc.data();
           setOutroUsuario({
-            id: outroId,               // ✅ agora tem o id
+            id: outroId, // ✅ agora tem o id
             nome: outro?.nome || "Usuário",
             foto: outro?.fotoPerfil || "",
           });
@@ -182,7 +182,7 @@ export default function Chat() {
     // Permissão: liberado se A segue B ou B segue A
     const verificarPermissao = async () => {
       try {
-        const meuDoc   = await getDoc(doc(db, "usuarios", user.uid));
+        const meuDoc = await getDoc(doc(db, "usuarios", user.uid));
         const outroDoc = await getDoc(doc(db, "usuarios", outroId));
 
         if (!meuDoc.exists() || !outroDoc.exists()) {
@@ -191,11 +191,11 @@ export default function Chat() {
           return;
         }
 
-        const meusDados   = meuDoc.data();
+        const meusDados = meuDoc.data();
         const outrosDados = outroDoc.data();
 
-        const euSigoEle  = (meusDados.seguindo   || []).includes(outroId);
-        const eleSegueEu = (outrosDados.seguindo  || []).includes(user.uid);
+        const euSigoEle = (meusDados.seguindo || []).includes(outroId);
+        const eleSegueEu = (outrosDados.seguindo || []).includes(user.uid);
 
         setPermitido(euSigoEle || eleSegueEu);
         if (!euSigoEle && !eleSegueEu) setLoadingMessages(false);
@@ -219,7 +219,7 @@ export default function Chat() {
 
     const q = query(
       collection(db, "chats", chatId, "mensagens"),
-      orderBy("createdAt", "asc")
+      orderBy("createdAt", "asc"),
     );
 
     const unsubscribe = onSnapshot(q, async (snapshot) => {
@@ -243,7 +243,7 @@ export default function Chat() {
             } catch (e) {
               console.log("Erro ao marcar como visto:", e);
             }
-          })
+          }),
         );
       }
     });
@@ -372,12 +372,15 @@ export default function Chat() {
     if (diff < 3600) return `${Math.floor(diff / 60)} min`;
     if (diff < 86400) return `${Math.floor(diff / 3600)} h`;
     if (diff < 604800) return `${Math.floor(diff / 86400)} d`;
-    return data.toLocaleDateString("pt-BR", { day: "2-digit", month: "2-digit" });
+    return data.toLocaleDateString("pt-BR", {
+      day: "2-digit",
+      month: "2-digit",
+    });
   };
 
   const conversasFiltradas = conversas
     ? conversas.filter((c) =>
-        c.nome.toLowerCase().includes(busca.toLowerCase())
+        c.nome.toLowerCase().includes(busca.toLowerCase()),
       )
     : [];
 
@@ -462,11 +465,13 @@ export default function Chat() {
                   <div className="conversa-vazia">
                     {busca ? (
                       <>
-                        😕 Nenhuma conversa encontrada para "<strong>{busca}</strong>"
+                        😕 Nenhuma conversa encontrada para "
+                        <strong>{busca}</strong>"
                       </>
                     ) : (
                       <>
-                        🎣 Você ainda não segue ninguém.<br />
+                        🎣 Você ainda não segue ninguém.
+                        <br />
                         Descubra pescadores na pesquisa!
                       </>
                     )}
@@ -476,48 +481,41 @@ export default function Chat() {
                     <div
                       key={c.chatId}
                       className={`conversation-item ${chatId === c.chatId ? "active" : ""}`}
-                    >
+                      onClick={() => navigate(`/chat/${c.chatId}`)}
+                    >                          
+
                       {/* CLIQUE NO CONTAINER PRINCIPAL → ABRE O CHAT */}
                       <div
                         className="conversation-item__chat-area"
                         onClick={() => navigate(`/chat/${c.chatId}`)}
-                        style={{ display: 'flex', flex: 1, alignItems: 'center', gap: '12px' }}
+                        style={{
+                          display: "flex",
+                          flex: 1,
+                          alignItems: "center",
+                          gap: "12px",
+                        }}
                       >
                         {/* AVATAR: navega para perfil com stopPropagation */}
-                        <div
-                          className="conv-avatar"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            navigate(`/perfil/${c.outroId}`);
-                          }}
-                          style={{ cursor: 'pointer' }}
-                        >
-                          {c.foto ? (
-                            <img src={c.foto} alt={c.nome} />
-                          ) : (
-                            <div className="fallback">
-                              {c.nome.charAt(0).toUpperCase()}
-                            </div>
-                          )}
-                        </div>
+                      <div className="conv-avatar">
+                        {c.foto ? (
+                          <img src={c.foto} alt={c.nome} />
+                        ) : (
+                          <div className="fallback">
+                            {c.nome.charAt(0).toUpperCase()}
+                          </div>
+                        )}
+                      </div>
 
                         <div className="conv-info">
                           <div className="conv-top">
                             {/* NOME: navega para perfil com stopPropagation */}
-                            <span
-                              className="conv-name"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                navigate(`/perfil/${c.outroId}`);
-                              }}
-                              style={{ cursor: 'pointer' }}
-                            >
-                              {c.nome}
-                            </span>
-                            <span className="conv-time">{tempoRelativo(c.ultimaData)}</span>
+<span className="conv-name">{c.nome}</span>
+<span className="conv-time">{tempoRelativo(c.ultimaData)}</span>
                           </div>
                           <div className="conv-bottom">
-                            <span className="conv-preview">{c.ultimaMensagem}</span>
+                            <span className="conv-preview">
+                              {c.ultimaMensagem}
+                            </span>
                             {c.naoLidas > 0 && (
                               <span className="conv-badge">{c.naoLidas}</span>
                             )}
@@ -544,7 +542,7 @@ export default function Chat() {
                 {Array.from({ length: 4 }).map((_, i) => (
                   <div
                     key={i}
-                    className={`skeleton-message ${i % 2 === 0 ? 'skeleton--mine' : 'skeleton--theirs'}`}
+                    className={`skeleton-message ${i % 2 === 0 ? "skeleton--mine" : "skeleton--theirs"}`}
                   >
                     <div className="skeleton-avatar" />
                     <div className="skeleton-bubble">
@@ -580,7 +578,9 @@ export default function Chat() {
                       onClick={() => navigate("/chat")}
                       title="Voltar"
                     >
-                      <span className="material-symbols-outlined">arrow_back</span>
+                      <span className="material-symbols-outlined">
+                        arrow_back
+                      </span>
                     </button>
                   )}
                   <div className="chat-header-left" key={chatId}>
@@ -588,7 +588,7 @@ export default function Chat() {
                     <div
                       className="chat-header-avatar"
                       onClick={() => navigate(`/perfil/${outroUsuario?.id}`)}
-                      style={{ cursor: 'pointer' }}
+                      style={{ cursor: "pointer" }}
                     >
                       {outroUsuario?.foto ? (
                         <img src={outroUsuario.foto} alt={outroUsuario.nome} />
@@ -602,7 +602,7 @@ export default function Chat() {
                       {/* NOME CLICÁVEL */}
                       <h3
                         onClick={() => navigate(`/perfil/${outroUsuario?.id}`)}
-                        style={{ cursor: 'pointer' }}
+                        style={{ cursor: "pointer" }}
                       >
                         {outroUsuario?.nome || "Pescador"}
                       </h3>
@@ -621,10 +621,14 @@ export default function Chat() {
                       <span className="material-symbols-outlined">call</span>
                     </button>
                     <button className="icon-btn" title="Vídeo">
-                      <span className="material-symbols-outlined">videocam</span>
+                      <span className="material-symbols-outlined">
+                        videocam
+                      </span>
                     </button>
                     <button className="icon-btn" title="Mais opções">
-                      <span className="material-symbols-outlined">more_vert</span>
+                      <span className="material-symbols-outlined">
+                        more_vert
+                      </span>
                     </button>
                   </div>
                 </header>
@@ -663,7 +667,9 @@ export default function Chat() {
                     onClick={scrollToBottom}
                     title="Rolar para baixo"
                   >
-                    <span className="material-symbols-outlined">arrow_downward</span>
+                    <span className="material-symbols-outlined">
+                      arrow_downward
+                    </span>
                   </button>
                 )}
 
@@ -681,7 +687,9 @@ export default function Chat() {
                         }
                       }}
                       placeholder="Digite uma mensagem..."
-                      onKeyDown={(e) => e.key === "Enter" && !e.shiftKey && enviarMensagem()}
+                      onKeyDown={(e) =>
+                        e.key === "Enter" && !e.shiftKey && enviarMensagem()
+                      }
                       maxLength={500}
                     />
                     <button className="btn-attach" title="Emoji">

--- a/src/pages/chat/Chat.jsx
+++ b/src/pages/chat/Chat.jsx
@@ -112,6 +112,7 @@ export default function Chat() {
               ultimaMensagem: ultimaMsg,
               ultimaData: ultimaData,
               naoLidas,
+              outroId: id, // ✅ guarda o ID do outro usuário para navegação
             };
 
             return [nova, ...outras].sort((a, b) => {
@@ -145,7 +146,7 @@ export default function Chat() {
   }, [chatId]);
 
   // =========================
-  // 🔒 Permissão + dados do outro usuário
+  // 🔒 Permissão + dados do outro usuário (inclui ID)
   // Chat liberado se A segue B ou B segue A
   // =========================
   useEffect(() => {
@@ -159,13 +160,14 @@ export default function Chat() {
     const ids = chatId.split("_");
     const outroId = ids.find((id) => id !== user.uid);
 
-    // Carrega dados do outro usuário (one-shot)
+    // Carrega dados do outro usuário (one-shot) – INCLUI O ID
     const carregarOutroUsuario = async () => {
       try {
         const outroDoc = await getDoc(doc(db, "usuarios", outroId));
         if (outroDoc.exists()) {
           const outro = outroDoc.data();
           setOutroUsuario({
+            id: outroId,               // ✅ agora tem o id
             nome: outro?.nome || "Usuário",
             foto: outro?.fotoPerfil || "",
           });
@@ -178,7 +180,6 @@ export default function Chat() {
     carregarOutroUsuario();
 
     // Permissão: liberado se A segue B ou B segue A
-    // Sem chat_permissions — qualquer relacionamento de seguir libera o chat
     const verificarPermissao = async () => {
       try {
         const meuDoc   = await getDoc(doc(db, "usuarios", user.uid));
@@ -227,7 +228,7 @@ export default function Chat() {
         ...doc.data(),
       }));
       setMensagens(msgs);
-      setLoadingMessages(false); // desliga skeleton
+      setLoadingMessages(false);
 
       const mensagensParaAtualizar = snapshot.docs.filter((d) => {
         const m = d.data();
@@ -475,27 +476,52 @@ export default function Chat() {
                     <div
                       key={c.chatId}
                       className={`conversation-item ${chatId === c.chatId ? "active" : ""}`}
-                      onClick={() => navigate(`/chat/${c.chatId}`)}
                     >
-                      <div className="conv-avatar">
-                        {c.foto ? (
-                          <img src={c.foto} alt={c.nome} />
-                        ) : (
-                          <div className="fallback">
-                            {c.nome.charAt(0).toUpperCase()}
-                          </div>
-                        )}
-                      </div>
-                      <div className="conv-info">
-                        <div className="conv-top">
-                          <span className="conv-name">{c.nome}</span>
-                          <span className="conv-time">{tempoRelativo(c.ultimaData)}</span>
-                        </div>
-                        <div className="conv-bottom">
-                          <span className="conv-preview">{c.ultimaMensagem}</span>
-                          {c.naoLidas > 0 && (
-                            <span className="conv-badge">{c.naoLidas}</span>
+                      {/* CLIQUE NO CONTAINER PRINCIPAL → ABRE O CHAT */}
+                      <div
+                        className="conversation-item__chat-area"
+                        onClick={() => navigate(`/chat/${c.chatId}`)}
+                        style={{ display: 'flex', flex: 1, alignItems: 'center', gap: '12px' }}
+                      >
+                        {/* AVATAR: navega para perfil com stopPropagation */}
+                        <div
+                          className="conv-avatar"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            navigate(`/perfil/${c.outroId}`);
+                          }}
+                          style={{ cursor: 'pointer' }}
+                        >
+                          {c.foto ? (
+                            <img src={c.foto} alt={c.nome} />
+                          ) : (
+                            <div className="fallback">
+                              {c.nome.charAt(0).toUpperCase()}
+                            </div>
                           )}
+                        </div>
+
+                        <div className="conv-info">
+                          <div className="conv-top">
+                            {/* NOME: navega para perfil com stopPropagation */}
+                            <span
+                              className="conv-name"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                navigate(`/perfil/${c.outroId}`);
+                              }}
+                              style={{ cursor: 'pointer' }}
+                            >
+                              {c.nome}
+                            </span>
+                            <span className="conv-time">{tempoRelativo(c.ultimaData)}</span>
+                          </div>
+                          <div className="conv-bottom">
+                            <span className="conv-preview">{c.ultimaMensagem}</span>
+                            {c.naoLidas > 0 && (
+                              <span className="conv-badge">{c.naoLidas}</span>
+                            )}
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -514,7 +540,6 @@ export default function Chat() {
                 <span>Escolha um pescador para começar a conversar</span>
               </div>
             ) : permitido === null || loadingMessages ? (
-              // 🔄 Skeleton shimmer enquanto carrega
               <div className="chat-messages chat-messages--loading">
                 {Array.from({ length: 4 }).map((_, i) => (
                   <div
@@ -558,9 +583,13 @@ export default function Chat() {
                       <span className="material-symbols-outlined">arrow_back</span>
                     </button>
                   )}
-                   <div className="chat-header-left" key={chatId}>
-                  <div className="chat-header-left">
-                    <div className="chat-header-avatar">
+                  <div className="chat-header-left" key={chatId}>
+                    {/* AVATAR CLICÁVEL */}
+                    <div
+                      className="chat-header-avatar"
+                      onClick={() => navigate(`/perfil/${outroUsuario?.id}`)}
+                      style={{ cursor: 'pointer' }}
+                    >
                       {outroUsuario?.foto ? (
                         <img src={outroUsuario.foto} alt={outroUsuario.nome} />
                       ) : (
@@ -570,7 +599,13 @@ export default function Chat() {
                       )}
                     </div>
                     <div className="chat-header-info">
-                      <h3>{outroUsuario?.nome || "Pescador"}</h3>
+                      {/* NOME CLICÁVEL */}
+                      <h3
+                        onClick={() => navigate(`/perfil/${outroUsuario?.id}`)}
+                        style={{ cursor: 'pointer' }}
+                      >
+                        {outroUsuario?.nome || "Pescador"}
+                      </h3>
                       {digitando ? (
                         <span className="digitando">digitando...</span>
                       ) : (
@@ -580,7 +615,6 @@ export default function Chat() {
                         </span>
                       )}
                     </div>
-                  </div>
                   </div>
                   <div className="chat-header-actions">
                     <button className="icon-btn" title="Ligar">

--- a/src/pages/chat/chat.css
+++ b/src/pages/chat/chat.css
@@ -1255,3 +1255,19 @@ body.dark-mode .skeleton-line {
     opacity: 1;
   }
 }
+
+/* ── Cursor pointer para elementos clicáveis do perfil ── */
+.chat-header-avatar,
+.chat-header-info h3,
+.conv-avatar,
+.conv-name {
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.chat-header-avatar:hover,
+.chat-header-info h3:hover,
+.conv-avatar:hover,
+.conv-name:hover {
+  opacity: 0.85;
+}


### PR DESCRIPTION
# feat(chat): navegação para o perfil ao clicar na foto ou nome do usuário

## Resumo
Este PR adiciona a capacidade de navegar para o perfil do usuário a partir da tela de chat, clicando na foto ou no nome do contato. A navegação foi limitada apenas ao cabeçalho do chat para melhor usabilidade em dispositivos móveis (evita toques acidentais em mensagens).

## Principais alterações

### Navegação para perfil
- **Clicar na foto do usuário** no cabeçalho do chat → redireciona para o perfil daquele usuário.
- **Clicar no nome do usuário** no cabeçalho do chat → redireciona para o perfil.

### Restrição de usabilidade mobile
- A navegação foi **limitada apenas ao header do chat** (área superior com avatar e nome).
- Evita que cliques acidentais em mensagens, bolhas ou outros elementos da lista de conversas disparem navegação indesejada.

## Commits relacionados
- `feat(chat): permite navegar ao perfil clicando na foto ou nome`
- `refactor(chat): limita navegação ao perfil apenas no header do chat (usabilidade mobile)`

## Observações
- A navegação é consistente com o restante do aplicativo (perfil visualizado em `/perfil/:uid`).
- A restrição ao header evita frustração em telas pequenas, onde o usuário pode tocar sem querer na área do cabeçalho.