### PR TITLE
Feature/notificacao foto remetente

### DIFF
--- a/src/components/NotifToast/NotifToast.css
+++ b/src/components/NotifToast/NotifToast.css
@@ -123,6 +123,22 @@
   flex-shrink: 0;
   position: relative;
   letter-spacing: 0.5px;
+  overflow: hidden; /* garante que a foto não vaze do círculo */
+}
+
+/* Foto real */
+.notif-toast__avatar-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+  display: block;
+}
+
+/* Placeholder com iniciais */
+.notif-toast__avatar-iniciais {
+  line-height: 1;
+  user-select: none;
 }
 
 .notif-toast__avatar.seguidor   { background: #E6F1FB; color: #0C447C; }

--- a/src/components/NotifToast/NotifToast.jsx
+++ b/src/components/NotifToast/NotifToast.jsx
@@ -6,6 +6,8 @@ import {
   query,
   where,
   onSnapshot,
+  doc,
+  getDoc,
 } from 'firebase/firestore';
 import { observeAuthState } from '../../auth';
 import './NotifToast.css';
@@ -65,6 +67,24 @@ export default function NotifToast() {
   const seenIdsRef      = useRef(new Set());
   const timersRef       = useRef({});
   const toastCounterRef = useRef(0);
+  // Cache uid → fotoPerfil em memória: evita buscas repetidas para o mesmo remetente
+  const fotoCacheRef    = useRef({});
+
+  // Busca a foto do remetente com cache em memória.
+  // Retorna null se não tiver foto ou se falhar — nunca bloqueia o toast.
+  const fetchFoto = useCallback(async (uid) => {
+    if (!uid) return null;
+    if (uid in fotoCacheRef.current) return fotoCacheRef.current[uid];
+    try {
+      const snap = await getDoc(doc(db, 'usuarios', uid));
+      const foto = snap.exists() ? snap.data().fotoPerfil || null : null;
+      fotoCacheRef.current[uid] = foto;
+      return foto;
+    } catch {
+      fotoCacheRef.current[uid] = null;
+      return null;
+    }
+  }, []);
 
   // 🔐 Auth
   useEffect(() => {
@@ -130,21 +150,28 @@ export default function NotifToast() {
         seenIdsRef.current.add(notifId);
 
         const notif = { id: notifId, ...change.doc.data() };
+        // Normaliza: aceita tanto de_id (padrão) quanto deId (legado)
+        const remetenteId = notif.de_id ?? notif.deId ?? null;
 
         // ── Suprime o toast se o usuário já estiver na tela de notificações ──
         if (location.pathname.startsWith('/notificacao')) return;
 
         const toastId = ++toastCounterRef.current;
-        setToasts((prev) => {
-          const base = prev.length >= 3 ? prev.slice(1) : prev;
-          return [...base, { toastId, notif, saindo: false }];
+
+        // Busca a foto e só então enfileira o toast — a espera é rápida
+        // pois o cache em memória evita round-trips repetidos.
+        fetchFoto(remetenteId).then((fotoPerfil) => {
+          setToasts((prev) => {
+            const base = prev.length >= 3 ? prev.slice(1) : prev;
+            return [...base, { toastId, notif, fotoPerfil, saindo: false }];
+          });
+          setTimeout(() => agendarFechamento(toastId), 50);
         });
-        setTimeout(() => agendarFechamento(toastId), 50);
       });
     });
 
     return unsub;
-  }, [user, location.pathname, agendarFechamento]);
+  }, [user, location.pathname, agendarFechamento, fetchFoto]);
 
   // ── Clique no corpo: vai para /notificacao ──
   const handleClickCorpo = useCallback((toastId) => {
@@ -195,7 +222,7 @@ export default function NotifToast() {
 
   return (
     <div className="notif-toast-stack" aria-live="polite" aria-label="Notificações">
-      {toasts.map(({ toastId, notif, saindo }) => {
+      {toasts.map(({ toastId, notif, fotoPerfil, saindo }) => {
         const cfg   = TIPO_CONFIG[notif.tipo] || TIPO_CONFIG.seguindo;
         const acoes = ACOES_RAPIDAS[notif.tipo] || [];
 
@@ -216,7 +243,15 @@ export default function NotifToast() {
 
             {/* Avatar */}
             <div className={`notif-toast__avatar ${cfg.avatarClass}`}>
-              {iniciais(notif.de)}
+              {fotoPerfil ? (
+                <img
+                  src={fotoPerfil}
+                  alt={notif.de}
+                  className="notif-toast__avatar-img"
+                />
+              ) : (
+                <span className="notif-toast__avatar-iniciais">{iniciais(notif.de)}</span>
+              )}
               <span className={`notif-toast__tipo-icon ${cfg.tipoClass}`}>
                 <span className="material-symbols-outlined">{cfg.icon}</span>
               </span>

--- a/src/pages/Notificacao/notificacao.css
+++ b/src/pages/Notificacao/notificacao.css
@@ -50,6 +50,18 @@ body {
   transition: all 0.15s ease;
 }
 
+.notif-tab:not(.active):hover {
+  background: #e8eef8;
+  border-color: #93aee8;
+  color: #062A6C;
+}
+
+.notif-tab.tab-arquivadas:not(.active):hover {
+  background: #f1f5f9;
+  border-color: #94a3b8;
+  color: #475569;
+}
+
 .notif-tab.active {
   background: #062A6C;
   color: #ffffff;
@@ -358,31 +370,42 @@ body {
 
 /* ================= DARK MODE ================= */
 body.dark-mode .notif-header {
-  background: #0f172a;
+  background: #1e1e1e;
   border-bottom-color: #334155;
 }
 
 body.dark-mode .notif-tab { color: #94a3b8; }
 
-body.dark-mode .notif-tab.active {
+body.dark-mode .notif-tab:not(.active):hover {
+  background: #1e2d45;
+  border-color: #93b4f0;
   color: #93b4f0;
-  border-bottom-color: #93b4f0;
+}
+
+body.dark-mode .notif-tab.tab-arquivadas:not(.active):hover {
+  background: #1e293b;
+  border-color: #475569;
+  color: #94a3b8;
+}
+
+body.dark-mode .notif-tab.active {
+  color: #ffffff;
 }
 
 body.dark-mode .notif-tab.tab-arquivadas.active {
-  color: #64748b;
+  color: #ffffff;
   border-bottom-color: #64748b;
 }
 
 body.dark-mode .notif-tab.active .tab-badge { background: #062A6C; }
 
-body.dark-mode .container-notificacoes { background: #0f172a; }
+body.dark-mode .container-notificacoes { background: #1e1e1e; }
 body.dark-mode .section-label { color: #64748b; }
 
 body.dark-mode .arquivo-aviso {
-  background: #1e293b;
-  border-color: #334155;
-  color: #64748b;
+  background: #ffffff;
+  border-color: #ffffff;
+
 }
 
 body.dark-mode .notif-card {
@@ -533,69 +556,3 @@ body.dark-mode .notif-loading {
     bottom: calc(64px + env(safe-area-inset-bottom) + 12px);
   }
 }
-/* ================= FOTO DO AVATAR — CIRCULAR ================= */
-.notif-avatar-img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  border-radius: 50%;
-  display: block;
-}
-
-.notif-avatar-iniciais {
-  line-height: 1;
-  user-select: none;
-  font-weight: 600;
-  letter-spacing: 0.5px;
-}
-
-/* ================= BOTÕES DE AÇÃO CONTEXTUAL ================= */
-.notif-acoes {
-  display: flex;
-  gap: 6px;
-  margin-top: 8px;
-  flex-wrap: wrap;
-}
-
-.notif-btn-acao {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px 12px;
-  border-radius: 20px;
-  border: 1.5px solid;
-  font-size: 11.5px;
-  font-family: 'Open Sans', Arial, sans-serif;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s, transform 0.12s;
-  white-space: nowrap;
-  background: transparent;
-}
-
-.notif-btn-acao:active { transform: scale(0.96); }
-.notif-btn-acao .material-symbols-outlined { font-size: 13px; }
-
-.notif-btn-acao.seguindo   { background: #E6F1FB; border-color: #185FA5; color: #0C447C; }
-.notif-btn-acao.seguindo:hover { background: #185FA5; color: #fff; }
-
-.notif-btn-acao.curtida    { background: #FBEAF0; border-color: #993556; color: #72243E; }
-.notif-btn-acao.curtida:hover { background: #993556; color: #fff; }
-
-.notif-btn-acao.comentario { background: #E1F5EE; border-color: #0F6E56; color: #085041; }
-.notif-btn-acao.comentario:hover { background: #0F6E56; color: #fff; }
-
-.notif-btn-acao.mensagem   { background: #FAEEDA; border-color: #854F0B; color: #633806; }
-.notif-btn-acao.mensagem:hover { background: #854F0B; color: #fff; }
-
-body.dark-mode .notif-btn-acao.seguindo   { background: #0d2240; border-color: #93b4f0; color: #93b4f0; }
-body.dark-mode .notif-btn-acao.seguindo:hover { background: #93b4f0; color: #0f172a; }
-
-body.dark-mode .notif-btn-acao.curtida    { background: #2d1020; border-color: #f0a3be; color: #f0a3be; }
-body.dark-mode .notif-btn-acao.curtida:hover { background: #f0a3be; color: #0f172a; }
-
-body.dark-mode .notif-btn-acao.comentario { background: #0b2a22; border-color: #6ed9ba; color: #6ed9ba; }
-body.dark-mode .notif-btn-acao.comentario:hover { background: #6ed9ba; color: #0f172a; }
-
-body.dark-mode .notif-btn-acao.mensagem   { background: #2b1d06; border-color: #f0c98a; color: #f0c98a; }
-body.dark-mode .notif-btn-acao.mensagem:hover { background: #f0c98a; color: #0f172a; }

--- a/src/pages/Notificacao/notificacao.css
+++ b/src/pages/Notificacao/notificacao.css
@@ -201,6 +201,14 @@ body {
 .notif-avatar.comentario { background: #E1F5EE; color: #085041; }
 .notif-avatar.mensagem   { background: #FAEEDA; color: #633806; }
 
+.notif-avatar-img {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+  display: block;
+}
+
 /* ================= ÍCONE DE TIPO ================= */
 .tipo-icon {
   position: absolute;

--- a/src/pages/Notificacao/notificacao.css
+++ b/src/pages/Notificacao/notificacao.css
@@ -533,3 +533,69 @@ body.dark-mode .notif-loading {
     bottom: calc(64px + env(safe-area-inset-bottom) + 12px);
   }
 }
+/* ================= FOTO DO AVATAR — CIRCULAR ================= */
+.notif-avatar-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+  display: block;
+}
+
+.notif-avatar-iniciais {
+  line-height: 1;
+  user-select: none;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+/* ================= BOTÕES DE AÇÃO CONTEXTUAL ================= */
+.notif-acoes {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+
+.notif-btn-acao {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 12px;
+  border-radius: 20px;
+  border: 1.5px solid;
+  font-size: 11.5px;
+  font-family: 'Open Sans', Arial, sans-serif;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, transform 0.12s;
+  white-space: nowrap;
+  background: transparent;
+}
+
+.notif-btn-acao:active { transform: scale(0.96); }
+.notif-btn-acao .material-symbols-outlined { font-size: 13px; }
+
+.notif-btn-acao.seguindo   { background: #E6F1FB; border-color: #185FA5; color: #0C447C; }
+.notif-btn-acao.seguindo:hover { background: #185FA5; color: #fff; }
+
+.notif-btn-acao.curtida    { background: #FBEAF0; border-color: #993556; color: #72243E; }
+.notif-btn-acao.curtida:hover { background: #993556; color: #fff; }
+
+.notif-btn-acao.comentario { background: #E1F5EE; border-color: #0F6E56; color: #085041; }
+.notif-btn-acao.comentario:hover { background: #0F6E56; color: #fff; }
+
+.notif-btn-acao.mensagem   { background: #FAEEDA; border-color: #854F0B; color: #633806; }
+.notif-btn-acao.mensagem:hover { background: #854F0B; color: #fff; }
+
+body.dark-mode .notif-btn-acao.seguindo   { background: #0d2240; border-color: #93b4f0; color: #93b4f0; }
+body.dark-mode .notif-btn-acao.seguindo:hover { background: #93b4f0; color: #0f172a; }
+
+body.dark-mode .notif-btn-acao.curtida    { background: #2d1020; border-color: #f0a3be; color: #f0a3be; }
+body.dark-mode .notif-btn-acao.curtida:hover { background: #f0a3be; color: #0f172a; }
+
+body.dark-mode .notif-btn-acao.comentario { background: #0b2a22; border-color: #6ed9ba; color: #6ed9ba; }
+body.dark-mode .notif-btn-acao.comentario:hover { background: #6ed9ba; color: #0f172a; }
+
+body.dark-mode .notif-btn-acao.mensagem   { background: #2b1d06; border-color: #f0c98a; color: #f0c98a; }
+body.dark-mode .notif-btn-acao.mensagem:hover { background: #f0c98a; color: #0f172a; }

--- a/src/pages/Notificacao/notificacao.css
+++ b/src/pages/Notificacao/notificacao.css
@@ -370,7 +370,7 @@ body {
 
 /* ================= DARK MODE ================= */
 body.dark-mode .notif-header {
-  background: #1e1e1e;
+  background: #0f172a;
   border-bottom-color: #334155;
 }
 
@@ -389,23 +389,24 @@ body.dark-mode .notif-tab.tab-arquivadas:not(.active):hover {
 }
 
 body.dark-mode .notif-tab.active {
-  color: #ffffff;
+  color: #93b4f0;
+  border-bottom-color: #93b4f0;
 }
 
 body.dark-mode .notif-tab.tab-arquivadas.active {
-  color: #ffffff;
+  color: #64748b;
   border-bottom-color: #64748b;
 }
 
 body.dark-mode .notif-tab.active .tab-badge { background: #062A6C; }
 
-body.dark-mode .container-notificacoes { background: #1e1e1e; }
+body.dark-mode .container-notificacoes { background: #0f172a; }
 body.dark-mode .section-label { color: #64748b; }
 
 body.dark-mode .arquivo-aviso {
-  background: #ffffff;
-  border-color: #ffffff;
-
+  background: #1e293b;
+  border-color: #334155;
+  color: #64748b;
 }
 
 body.dark-mode .notif-card {
@@ -537,4 +538,70 @@ body.dark-mode .notif-loading {
     left: 16px;
     bottom: calc(64px + env(safe-area-inset-bottom) + 12px);
   }
+}    
+/* ================= FOTO DO AVATAR — CIRCULAR ================= */
+.notif-avatar-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+  display: block;
 }
+
+.notif-avatar-iniciais {
+  line-height: 1;
+  user-select: none;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+/* ================= BOTÕES DE AÇÃO CONTEXTUAL ================= */
+.notif-acoes {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+
+.notif-btn-acao {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 12px;
+  border-radius: 20px;
+  border: 1.5px solid;
+  font-size: 11.5px;
+  font-family: 'Open Sans', Arial, sans-serif;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, transform 0.12s;
+  white-space: nowrap;
+  background: transparent;
+}
+
+.notif-btn-acao:active { transform: scale(0.96); }
+.notif-btn-acao .material-symbols-outlined { font-size: 13px; }
+
+.notif-btn-acao.seguindo   { background: #E6F1FB; border-color: #185FA5; color: #0C447C; }
+.notif-btn-acao.seguindo:hover { background: #185FA5; color: #fff; }
+
+.notif-btn-acao.curtida    { background: #FBEAF0; border-color: #993556; color: #72243E; }
+.notif-btn-acao.curtida:hover { background: #993556; color: #fff; }
+
+.notif-btn-acao.comentario { background: #E1F5EE; border-color: #0F6E56; color: #085041; }
+.notif-btn-acao.comentario:hover { background: #0F6E56; color: #fff; }
+
+.notif-btn-acao.mensagem   { background: #FAEEDA; border-color: #854F0B; color: #633806; }
+.notif-btn-acao.mensagem:hover { background: #854F0B; color: #fff; }
+
+body.dark-mode .notif-btn-acao.seguindo   { background: #0d2240; border-color: #93b4f0; color: #93b4f0; }
+body.dark-mode .notif-btn-acao.seguindo:hover { background: #93b4f0; color: #0f172a; }
+
+body.dark-mode .notif-btn-acao.curtida    { background: #2d1020; border-color: #f0a3be; color: #f0a3be; }
+body.dark-mode .notif-btn-acao.curtida:hover { background: #f0a3be; color: #0f172a; }
+
+body.dark-mode .notif-btn-acao.comentario { background: #0b2a22; border-color: #6ed9ba; color: #6ed9ba; }
+body.dark-mode .notif-btn-acao.comentario:hover { background: #6ed9ba; color: #0f172a; }
+
+body.dark-mode .notif-btn-acao.mensagem   { background: #2b1d06; border-color: #f0c98a; color: #f0c98a; }
+body.dark-mode .notif-btn-acao.mensagem:hover { background: #f0c98a; color: #0f172a; }

--- a/src/pages/Notificacao/notificacao.css
+++ b/src/pages/Notificacao/notificacao.css
@@ -439,7 +439,7 @@ body.dark-mode .notif-loading {
 }
 
 /* ================= MOBILE ================= */
-@media (max-width: 900px) {
+@media (max-width: 1098px) {
   .notif-wrapper {
     height: 100vh;
     height: 100dvh;
@@ -502,11 +502,6 @@ body.dark-mode .notif-loading {
     padding-bottom: calc(72px + 16px);
   }
 
-  .fab-marcar {
-    left: 16px;
-    bottom: calc(64px + env(safe-area-inset-bottom) + 12px);
-  }
-
   .notif-card { padding: 12px; }
   .notif-text { font-size: 13px; }
 }
@@ -529,5 +524,10 @@ body.dark-mode .notif-loading {
     background: #334155;
     color: #e2e8f0;
     border-color: #475569;
+  }
+
+    .fab-marcar {
+    left: 16px;
+    bottom: calc(64px + env(safe-area-inset-bottom) + 12px);
   }
 }

--- a/src/pages/Notificacao/notificacao.css
+++ b/src/pages/Notificacao/notificacao.css
@@ -370,7 +370,7 @@ body {
 
 /* ================= DARK MODE ================= */
 body.dark-mode .notif-header {
-  background: #0f172a;
+  background: #1e1e1e;
   border-bottom-color: #334155;
 }
 
@@ -389,24 +389,23 @@ body.dark-mode .notif-tab.tab-arquivadas:not(.active):hover {
 }
 
 body.dark-mode .notif-tab.active {
-  color: #93b4f0;
-  border-bottom-color: #93b4f0;
+  color: #ffffff;
 }
 
 body.dark-mode .notif-tab.tab-arquivadas.active {
-  color: #64748b;
+  color: #ffffff;
   border-bottom-color: #64748b;
 }
 
 body.dark-mode .notif-tab.active .tab-badge { background: #062A6C; }
 
-body.dark-mode .container-notificacoes { background: #0f172a; }
+body.dark-mode .container-notificacoes { background: #1e1e1e; }
 body.dark-mode .section-label { color: #64748b; }
 
 body.dark-mode .arquivo-aviso {
-  background: #1e293b;
-  border-color: #334155;
-  color: #64748b;
+  background: #ffffff;
+  border-color: #ffffff;
+
 }
 
 body.dark-mode .notif-card {
@@ -538,21 +537,6 @@ body.dark-mode .notif-loading {
     left: 16px;
     bottom: calc(64px + env(safe-area-inset-bottom) + 12px);
   }
-}    
-/* ================= FOTO DO AVATAR — CIRCULAR ================= */
-.notif-avatar-img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  border-radius: 50%;
-  display: block;
-}
-
-.notif-avatar-iniciais {
-  line-height: 1;
-  user-select: none;
-  font-weight: 600;
-  letter-spacing: 0.5px;
 }
 
 /* ================= BOTÕES DE AÇÃO CONTEXTUAL ================= */
@@ -562,7 +546,7 @@ body.dark-mode .notif-loading {
   margin-top: 8px;
   flex-wrap: wrap;
 }
-
+ 
 .notif-btn-acao {
   display: inline-flex;
   align-items: center;
@@ -578,30 +562,30 @@ body.dark-mode .notif-loading {
   white-space: nowrap;
   background: transparent;
 }
-
+ 
 .notif-btn-acao:active { transform: scale(0.96); }
 .notif-btn-acao .material-symbols-outlined { font-size: 13px; }
-
+ 
 .notif-btn-acao.seguindo   { background: #E6F1FB; border-color: #185FA5; color: #0C447C; }
 .notif-btn-acao.seguindo:hover { background: #185FA5; color: #fff; }
-
+ 
 .notif-btn-acao.curtida    { background: #FBEAF0; border-color: #993556; color: #72243E; }
 .notif-btn-acao.curtida:hover { background: #993556; color: #fff; }
-
+ 
 .notif-btn-acao.comentario { background: #E1F5EE; border-color: #0F6E56; color: #085041; }
 .notif-btn-acao.comentario:hover { background: #0F6E56; color: #fff; }
-
+ 
 .notif-btn-acao.mensagem   { background: #FAEEDA; border-color: #854F0B; color: #633806; }
 .notif-btn-acao.mensagem:hover { background: #854F0B; color: #fff; }
-
+ 
 body.dark-mode .notif-btn-acao.seguindo   { background: #0d2240; border-color: #93b4f0; color: #93b4f0; }
 body.dark-mode .notif-btn-acao.seguindo:hover { background: #93b4f0; color: #0f172a; }
-
+ 
 body.dark-mode .notif-btn-acao.curtida    { background: #2d1020; border-color: #f0a3be; color: #f0a3be; }
 body.dark-mode .notif-btn-acao.curtida:hover { background: #f0a3be; color: #0f172a; }
-
+ 
 body.dark-mode .notif-btn-acao.comentario { background: #0b2a22; border-color: #6ed9ba; color: #6ed9ba; }
 body.dark-mode .notif-btn-acao.comentario:hover { background: #6ed9ba; color: #0f172a; }
-
+ 
 body.dark-mode .notif-btn-acao.mensagem   { background: #2b1d06; border-color: #f0c98a; color: #f0c98a; }
 body.dark-mode .notif-btn-acao.mensagem:hover { background: #f0c98a; color: #0f172a; }

--- a/src/pages/Notificacao/notificacao.css
+++ b/src/pages/Notificacao/notificacao.css
@@ -533,24 +533,6 @@ body.dark-mode .notif-loading {
 
 /* dark mode chips mobile */
 @media (max-width: 900px) {
-  body.dark-mode .notif-tab {
-    background: #1e293b;
-    border-color: #334155;
-    color: #94a3b8;
-  }
-
-  body.dark-mode .notif-tab.active {
-    background: #062A6C;
-    color: #ffffff;
-    border-color: #062A6C;
-  }
-
-  body.dark-mode .notif-tab.tab-arquivadas.active {
-    background: #334155;
-    color: #e2e8f0;
-    border-color: #475569;
-  }
-
     .fab-marcar {
     left: 16px;
     bottom: calc(64px + env(safe-area-inset-bottom) + 12px);

--- a/src/pages/Notificacao/notificacao.css
+++ b/src/pages/Notificacao/notificacao.css
@@ -23,9 +23,11 @@ body {
 /* ================= ABAS ================= */
 .notif-tabs {
   display: flex;
-  gap: 0;
+  gap: 6px;
   overflow-x: auto;
   scrollbar-width: none;
+  padding-bottom: 10px;
+  justify-content: center;
 }
 
 .notif-tabs::-webkit-scrollbar {
@@ -33,32 +35,32 @@ body {
 }
 
 .notif-tab {
-  padding: 10px 16px;
-  font-size: 13px;
+  padding: 6px 12px;
+  font-size: 11.5px;
   font-weight: 500;
   color: #64748b;
-  border-bottom: 2px solid transparent;
-  border-top: none;
-  border-left: none;
-  border-right: none;
+  border: 1px solid #e2e8f0;
+  border-radius: 50px;
+  background: #f8fafc;
   cursor: pointer;
   white-space: nowrap;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 6px;
-  transition: color 0.15s, border-color 0.15s;
-  background: transparent;
+  transition: all 0.15s ease;
 }
 
 .notif-tab.active {
-  color: #062A6C;
-  border-bottom-color: #062A6C;
+  background: #062A6C;
+  color: #ffffff;
+  border-color: #062A6C;
 }
 
 /* aba arquivadas tem cor diferente quando ativa */
 .notif-tab.tab-arquivadas.active {
-  color: #64748b;
-  border-bottom-color: #94a3b8;
+  background: #64748b;
+  color: #ffffff;
+  border-color: #64748b;
 }
 
 .notif-tab .tab-badge {

--- a/src/pages/Notificacao/notificacao.jsx
+++ b/src/pages/Notificacao/notificacao.jsx
@@ -22,6 +22,71 @@ import {
 
 import { observeAuthState } from "../../auth";
 
+// ── Hook: busca fotos de perfil em batch para os remetentes ──
+// Recebe a lista de notificações e devolve um mapa uid → fotoPerfil (string | null).
+// Re-busca apenas quando aparecem UIDs ainda não conhecidos — sem N+1.
+function useUserPhotos(notificacoes) {
+  const [fotoMap, setFotoMap] = useState({});
+
+  useEffect(() => {
+    const uidsNovos = [
+      ...new Set(notificacoes.map((n) => n.de_id ?? n.deId).filter(Boolean)),
+    ].filter((uid) => !(uid in fotoMap));
+
+    if (uidsNovos.length === 0) return;
+
+    const buscarFotos = async () => {
+      const promessas = uidsNovos.map((uid) =>
+        getDoc(doc(db, "usuarios", uid))
+          .then((snap) => [uid, snap.exists() ? snap.data().fotoPerfil || null : null])
+          .catch(() => [uid, null])
+      );
+      const resultados = await Promise.all(promessas);
+      setFotoMap((prev) => ({
+        ...prev,
+        ...Object.fromEntries(resultados),
+      }));
+    };
+
+    buscarFotos();
+    // fotoMap intencionalmente fora das deps para não criar loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [notificacoes]);
+
+  return fotoMap;
+}
+
+// ── AvatarNotif: foto real ou placeholder com iniciais (mesmo padrão da pesquisa) ──
+function AvatarNotif({ nome = "", fotoPerfil, tipoClass, icone }) {
+  const [imgError, setImgError] = useState(false);
+
+  const iniciais = nome
+    .split(" ")
+    .slice(0, 2)
+    .map((p) => p[0]?.toUpperCase() ?? "")
+    .join("");
+
+  const temFoto = fotoPerfil && !imgError;
+
+  return (
+    <div className={`notif-avatar ${tipoClass}`}>
+      {temFoto ? (
+        <img
+          src={fotoPerfil}
+          alt={nome}
+          className="notif-avatar-img"
+          onError={() => setImgError(true)}
+        />
+      ) : (
+        <span className="notif-avatar-iniciais">{iniciais}</span>
+      )}
+      <span className={`tipo-icon ${tipoClass}`}>
+        <span className="material-symbols-outlined">{icone}</span>
+      </span>
+    </div>
+  );
+}
+
 const TEMPO_ARQUIVAR_MS = 5 * 60 * 1000;
 
 const TIPOS = [
@@ -40,6 +105,9 @@ export default function Notificacao() {
   const [filtro, setFiltro] = useState("todas");
   // Mapa uid → bool: currentUser já segue aquela pessoa?
   const [seguindoMap, setSeguindoMap] = useState({});
+
+  // Mapa uid → fotoPerfil: fotos dos remetentes buscadas em batch
+  const fotoMap = useUserPhotos(notificacoes);
 
   const timersRef = useRef({});
 
@@ -355,6 +423,7 @@ export default function Notificacao() {
                         jaSeguindo={seguindoMap[n.de_id] || false}
                         onSeguirDeVolta={seguirDeVolta}
                         onDeixarDeSeguir={deixarDeSeguirNotif}
+                        fotoPerfil={fotoMap[n.de_id ?? n.deId] ?? null}
                       />
                     ))}
                   </div>
@@ -379,6 +448,7 @@ export default function Notificacao() {
                         jaSeguindo={seguindoMap[n.de_id] || false}
                         onSeguirDeVolta={seguirDeVolta}
                         onDeixarDeSeguir={deixarDeSeguirNotif}
+                        fotoPerfil={fotoMap[n.de_id ?? n.deId] ?? null}
                       />
                     ))}
                   </div>
@@ -412,6 +482,7 @@ export default function Notificacao() {
                       onLida={() => {}}
                       onExcluir={excluirArquivada}
                       isArquivada
+                      fotoPerfil={fotoMap[n.de_id ?? n.deId] ?? null}
                     />
                   ))}
                 </div>
@@ -440,7 +511,6 @@ export default function Notificacao() {
 function CardNotificacao({
   n,
   avatarClass,
-  iniciais,
   renderTexto,
   tempoRelativo,
   onLida,
@@ -451,6 +521,7 @@ function CardNotificacao({
   jaSeguindo = false,
   onSeguirDeVolta,
   onDeixarDeSeguir,
+  fotoPerfil = null,
 }) {
   const tipoClass = avatarClass(n.tipo);
   const [segundosRestantes, setSegundosRestantes] = useState(null);
@@ -499,12 +570,12 @@ function CardNotificacao({
       className={`notif-card ${n.lida ? "lida" : "nao-lida"} ${isArquivada ? "arquivada" : ""}`}
       onClick={() => onLida(n.id, n.lida)}
     >
-      <div className={`notif-avatar ${tipoClass}`}>
-        {iniciais(n.de)}
-        <span className={`tipo-icon ${tipoClass}`}>
-          <span className="material-symbols-outlined">{tipoIcone(n.tipo)}</span>
-        </span>
-      </div>
+      <AvatarNotif
+        nome={n.de}
+        fotoPerfil={fotoPerfil}
+        tipoClass={tipoClass}
+        icone={tipoIcone(n.tipo)}
+      />
 
       <div className="notif-content">
         <p className="notif-text">{renderTexto(n)}</p>

--- a/src/pages/Notificacao/notificacao.jsx
+++ b/src/pages/Notificacao/notificacao.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import Layout from "../../components/sidebar/layout";
 import "./notificacao.css";
 
@@ -99,6 +100,7 @@ const TIPOS = [
 ];
 
 export default function Notificacao() {
+  const navigate = useNavigate();
   const [user, setUser] = useState(null);
   const [notificacoes, setNotificacoes] = useState([]);
   const [arquivadas, setArquivadas] = useState([]);
@@ -424,6 +426,8 @@ export default function Notificacao() {
                         onSeguirDeVolta={seguirDeVolta}
                         onDeixarDeSeguir={deixarDeSeguirNotif}
                         fotoPerfil={fotoMap[n.de_id ?? n.deId] ?? null}
+                        navigate={navigate}
+                        currentUserId={user?.uid}
                       />
                     ))}
                   </div>
@@ -449,6 +453,8 @@ export default function Notificacao() {
                         onSeguirDeVolta={seguirDeVolta}
                         onDeixarDeSeguir={deixarDeSeguirNotif}
                         fotoPerfil={fotoMap[n.de_id ?? n.deId] ?? null}
+                        navigate={navigate}
+                        currentUserId={user?.uid}
                       />
                     ))}
                   </div>
@@ -507,7 +513,6 @@ export default function Notificacao() {
   );
 }
 
-// ── Card de Notificação ──
 function CardNotificacao({
   n,
   avatarClass,
@@ -522,6 +527,8 @@ function CardNotificacao({
   onSeguirDeVolta,
   onDeixarDeSeguir,
   fotoPerfil = null,
+  navigate,
+  currentUserId,
 }) {
   const tipoClass = avatarClass(n.tipo);
   const [segundosRestantes, setSegundosRestantes] = useState(null);
@@ -565,6 +572,73 @@ function CardNotificacao({
     }
   };
 
+  // ── Ações contextuais por tipo (igual ao NotifToast) ──
+  const handleAcao = (e, acao) => {
+    e.stopPropagation();
+    if (!navigate) return;
+    // Marca como lida ao interagir com qualquer ação contextual
+    onLida(n.id, n.lida);
+    switch (acao) {
+      case "perfil":
+        navigate(n.de_id ? `/perfil/${n.de_id}` : "/notificacao");
+        break;
+      case "post":
+        if (n.postId) {
+          navigate(`/post/${n.para}/${n.postId}`);
+        } else {
+          navigate("/notificacao");
+        }
+        break;
+      case "chat":
+        if (n.chatId) {
+          navigate(`/chat/${n.chatId}`);
+        } else if (n.de_id && currentUserId) {
+          const chatId = [n.de_id, currentUserId].sort().join("_");
+          navigate(`/chat/${chatId}`);
+        } else {
+          navigate("/chat");
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  const renderAcoes = () => {
+    if (isArquivada) return null;
+    switch (n.tipo) {
+      case "curtida":
+        return (
+          <div className="notif-acoes">
+            <button className="notif-btn-acao curtida" onClick={(e) => handleAcao(e, "post")}>
+              <span className="material-symbols-outlined">open_in_new</span>
+              Ver post
+            </button>
+          </div>
+        );
+      case "comentario":
+        return (
+          <div className="notif-acoes">
+            <button className="notif-btn-acao comentario" onClick={(e) => handleAcao(e, "post")}>
+              <span className="material-symbols-outlined">reply</span>
+              Responder
+            </button>
+          </div>
+        );
+      case "mensagem":
+        return (
+          <div className="notif-acoes">
+            <button className="notif-btn-acao mensagem" onClick={(e) => handleAcao(e, "chat")}>
+              <span className="material-symbols-outlined">reply</span>
+              Responder
+            </button>
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
+
   return (
     <div
       className={`notif-card ${n.lida ? "lida" : "nao-lida"} ${isArquivada ? "arquivada" : ""}`}
@@ -590,11 +664,11 @@ function CardNotificacao({
           )}
         </div>
 
-        {/* Botão "Seguir de volta" — apenas em notificações do tipo seguindo, não arquivadas */}
+        {/* Botão "Seguir de volta" — tipo seguindo */}
         {ehSeguindo && !isArquivada && (
-          <div className="notif-toast__acoes" style={{ marginTop: 8 }}>
+          <div className="notif-acoes">
             <button
-              className={`notif-toast__btn ${jaSeguindo ? "notif-btn-seguindo-ativo" : "notif-toast__btn--seguindo"}`}
+              className={`notif-btn-acao ${jaSeguindo ? "notif-btn-seguindo-ativo" : "seguindo"}`}
               onClick={handleFollow}
               disabled={loadingFollow}
             >
@@ -614,6 +688,9 @@ function CardNotificacao({
             </button>
           </div>
         )}
+
+        {/* Botões de ação: Ver post / Responder */}
+        {renderAcoes()}
       </div>
 
       <div className="notif-actions">

--- a/src/pages/VisualizacaoPost/VisualizacaoPost.jsx
+++ b/src/pages/VisualizacaoPost/VisualizacaoPost.jsx
@@ -92,7 +92,7 @@ const handleCurtir = async () => {
       await addDoc(collection(db, "notificacoes"), {
         tipo: "curtida",
         de: user.displayName || "Pescador",
-        deId: user.uid,
+        de_id: user.uid,
         para: userId,
         postId: postId,
         createdAt: serverTimestamp(),
@@ -141,7 +141,7 @@ const handleComentar = async () => {
       await addDoc(collection(db, "notificacoes"), {
         tipo: "comentario",
         de: user.displayName || "Pescador",
-        deId: user.uid,
+        de_id: user.uid,
         para: userId,
         texto: textoComentario,
         postId: postId,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -624,7 +624,7 @@ body.dark-mode .social i {
 
 /* Ajuste do container principal no modo escuro */
 body.dark-mode .main-layout-content {
-  background-color: #121212;
+  background-color: #1e1e1e;
 }
 
 /* Editar Perfil */


### PR DESCRIPTION
# feat(notificacao): foto do remetente em círculo, cache de imagens, ações contextuais e dark mode unificado

## Resumo
Este PR aprimora a tela de notificações e o toast global com a **exibição da foto de perfil do remetente em formato circular**, implementa **cache de fotos** para otimização, adiciona **ações contextuais** nos cards (Ver post, Responder), marca notificações como lidas ao clicar, padroniza o dark mode entre mobile/desktop, melhora o estilo das abas e botões, e ajusta o breakpoint para o botão flutuante (FAB) em mobile.

## Principais alterações

### Fotos do remetente
- **Avatar circular** (`border-radius: 50%`) em todos os cards de notificação e no toast.
- **Cache de fotos de perfil** implementado – evita múltiplos downloads da mesma imagem.
- Exibição consistente da foto do remetente (quando disponível).

### Ações contextuais
- **Botões de ação** nos cards de notificação:
  - `Ver post` – para notificações de curtida/comentário.
  - `Responder` – para notificações de seguidor (abre chat) ou mensagem.
- **Marca notificação como lida** ao clicar em qualquer ação contextual.
- **Classe renomeada** de `notif-toast__btn` para `notif-btn-acao` nos cards.

### Estilos e responsividade
- **Abas de filtro** – novo estilo com espaçamento, bordas arredondadas, cores atualizadas e **hover** (light/dark mode).
- **Hover nos cards** – melhor visibilidade em ambos os temas.
- **Dark mode unificado** – removida diferença entre mobile e desktop (cores consistentes em todas as resoluções).
- **Ajuste de breakpoint para FAB** – reposicionamento do botão de ação flutuante em mobile.
- **Cabeçalho, abas e botões** estilizados para dark mode.

### Toast global (NotifToast)
- Dark mode do `NotifToast` alinhado com o tema `black` do projeto.
- Cache de fotos também aplicado ao toast.

## Commits relacionados
- `feat(notificacao): implementa cache de fotos de perfil e exibição no toast`
- `fix(notificacao): Ajuste o ponto de interrupção da consulta de mídia móvel e reposicione o botão de ação flutuante`
- `style(notificacao): Melhoramos o estilo das abas com espaçamento, bordas e cores atualizados`
- `feat(notificacoes): adiciona ações contextuais, avatar circular e hover nos cards` (com vários subitens)
- `style(notificacoes): adiciona hover nas abas de filtro (light e dark mode)`
- `fix(notificacao): remove diferença de modo dark do mobile ao desktop`
- `style(notificacao): Atualize os estilos do modo escuro e adicione botões de ação contextuais com avatar circular`
- `style(notificacao): Atualize os estilos do modo escuro para cabeçalho, abas e botões`
- `feat(notificacao): adicionado img em circulo`

## Observações
- O cache de fotos reduz o consumo de rede e melhora a performance.
- A padronização do dark mode elimina inconsistências antigas entre versões mobile/desktop.
- As ações contextuais tornam a tela de notificações muito mais interativa e útil.
- Este PR complementa a funcionalidade de notificações em tempo real já existente.