### PR TITLE
fix: corrige public do firebase.json de dist para build (Create React…

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "public": "dist",
+    "public": "build",
     "ignore": [
       "firebase.json",
       "**/.*",


### PR DESCRIPTION
… App)

Corrige deploy no Firebase Hosting

firebase.json apontava para dist/ (padrão Vite)
Projeto usa Create React App que gera na pasta build/
Ajustado "public": "build" para refletir a estrutura corr