### PR TITLE
fix: corrigir tour de onboarding não ativando após cadastro

### DIFF
--- a/src/pages/Onboarding/Onboarding.jsx
+++ b/src/pages/Onboarding/Onboarding.jsx
@@ -257,10 +257,12 @@ export default function Onboarding() {
       console.error("Erro ao finalizar onboarding:", e);
     }
 
-    navigate("/home", {
-      state: { showTour: true },
-      replace: true,
-    });
+    // Ativa o tour via localStorage — é o que o layout.jsx lê para exibir o OnboardingTour
+    localStorage.setItem('tourAtivo', 'true');
+    localStorage.removeItem('tourConcluido');
+    localStorage.removeItem('tourCurrentStep'); // garante início sempre do step 0
+
+    navigate("/home", { replace: true });
   };
 
   /* ─── Render ─── */


### PR DESCRIPTION
# fix(tour): corrige tour de onboarding não ativando após cadastro

## Resumo
Este PR corrige um bug onde o tour de onboarding (tour de integração para novos usuários) não era ativado automaticamente após a conclusão do cadastro. Agora, o tour é disparado corretamente assim que o usuário finaliza o fluxo de criação de conta.

## Principais alterações
- Ajusta a lógica de verificação de “primeiro acesso” para disparar o tour imediatamente após o cadastro.
- Corrige possível condição onde o estado de onboarding não era atualizado no redirecionamento pós-cadastro.

## Commit relacionado
- `fix: corrigir tour de onboarding não ativando após cadastro`

## Testes sugeridos
1. Criar uma nova conta (cadastro completo, incluindo etapa de username).
2. Após o redirecionamento para a página inicial, o tour de onboarding deve iniciar automaticamente (sem necessidade de recarregar ou clicar em nada).
3. Usuários existentes (já logados) não devem ver o tour ao fazer login normalmente.

## Observações
- Esta correção garante que novos usuários recebam o tour guiado de integração, melhorando a experiência de primeiro uso.
- Não afeta a navegação ou o comportamento de usuários já cadastrados.